### PR TITLE
Force POSIX style paths (forward- instead of backslash) when creating tailwind config paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13140,7 +13140,7 @@
     },
     "packages/subframe-cli": {
       "name": "@subframe/cli",
-      "version": "1.178.0",
+      "version": "1.179.0",
       "license": "ISC",
       "dependencies": {
         "@antfu/ni": "0.21.8",

--- a/packages/subframe-cli/package.json
+++ b/packages/subframe-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subframe/cli",
-  "version": "1.178.0",
+  "version": "1.179.0",
   "description": "Subframe's CLI tool for syncing your code with Subframe designs.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/subframe-cli/src/sync-settings.ts
+++ b/packages/subframe-cli/src/sync-settings.ts
@@ -1,13 +1,12 @@
 import { existsSync, readFileSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { join as posixJoin } from "node:path/posix"
 import prompts from "prompts"
 import { DEFAULT_SUBFRAME_TS_ALIAS, ROOT_FOLDER_NAME } from "shared/constants"
 import { addAliasesToTSConfig, hasAliasSetup } from "./add-tsconfig-alias"
 import { ACCESS_TOKEN_FILENAME, SUBFRAME_DIR, SYNC_SETTINGS_FILENAME } from "./constants"
 import { abortOnState } from "./sync-helpers"
-import { exists, isDirectory } from "./utils/fs"
+import { exists, isDirectory, posixJoin } from "./utils/fs"
 
 export interface SyncSettingsConfig {
   directory: string

--- a/packages/subframe-cli/src/sync-settings.ts
+++ b/packages/subframe-cli/src/sync-settings.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import { join as posixJoin } from "node:path/posix"
 import prompts from "prompts"
 import { DEFAULT_SUBFRAME_TS_ALIAS, ROOT_FOLDER_NAME } from "shared/constants"
 import { addAliasesToTSConfig, hasAliasSetup } from "./add-tsconfig-alias"
@@ -82,7 +83,7 @@ export async function setupSyncSettings(
     })
 
     // NOTE: join will remove the trailing slash
-    config.directory = "./" + join(response.directory, ROOT_FOLDER_NAME)
+    config.directory = "./" + posixJoin(response.directory, ROOT_FOLDER_NAME)
   }
 
   if (!options.importAlias) {
@@ -107,7 +108,7 @@ export async function setupSyncSettings(
 
       const aliases = {
         /** just the one alias for now */
-        [response.componentsDirAlias]: [`${config.directory}/*`],
+        [response.componentsDirAlias]: [posixJoin(config.directory, "/*")],
       }
 
       if (await exists(tsConfigPath)) {

--- a/packages/subframe-cli/src/transforms/tailwind.ts
+++ b/packages/subframe-cli/src/transforms/tailwind.ts
@@ -1,4 +1,5 @@
-import { join, relative } from "node:path"
+import { relative } from "node:path"
+import { join } from "node:path/posix"
 import { ts } from "ts-morph"
 
 type PresetsProperty = ts.PropertyAssignment & {

--- a/packages/subframe-cli/src/transforms/tailwind.ts
+++ b/packages/subframe-cli/src/transforms/tailwind.ts
@@ -1,6 +1,6 @@
 import { relative } from "node:path"
-import { join } from "node:path/posix"
 import { ts } from "ts-morph"
+import { posixJoin } from "../utils/fs"
 
 type PresetsProperty = ts.PropertyAssignment & {
   name: (ts.Identifier | ts.StringLiteral) & { text: "presets" }
@@ -37,7 +37,7 @@ export function isContentProperty(property: ts.ObjectLiteralElementLike): proper
 }
 
 export function makeSubframeContentGlob(cwd: string, subframeDirPath: string) {
-  return "./" + join(relative(cwd, subframeDirPath), "**", "*.{tsx,ts,js,jsx}")
+  return "./" + posixJoin(relative(cwd, subframeDirPath), "**", "*.{tsx,ts,js,jsx}")
 }
 
 export function hasSubframeContentGlob(globs: ts.ArrayLiteralExpression, cwd: string, subframeDirPath: string) {
@@ -53,7 +53,7 @@ export function hasSubframeContentGlob(globs: ts.ArrayLiteralExpression, cwd: st
 }
 
 function getSubframeTailwindPresetPath(cwd: string, subframeDirPath: string): string {
-  return "./" + join(relative(cwd, subframeDirPath), "tailwind.config.js")
+  return "./" + posixJoin(relative(cwd, subframeDirPath), "tailwind.config.js")
 }
 
 export function makeSubframeRequire(cwd: string, subframeDirPath: string) {

--- a/packages/subframe-cli/src/utils/fs.ts
+++ b/packages/subframe-cli/src/utils/fs.ts
@@ -1,5 +1,10 @@
 import { mkdir, stat } from "node:fs/promises"
 
+// NOTE: must be used for joining paths that will be used in JavaScript code.
+// This is because different OSes use different path separators e.g. Windows uses backslashes,
+// and JavaScript only supports forward slashes.
+export { join as posixJoin } from "node:path/posix"
+
 export async function exists(path: string): Promise<boolean> {
   const pathStat = await stat(path).catch(() => null)
   if (!pathStat) {


### PR DESCRIPTION
What it says on the tin