### PR TITLE
docs: add DPA to FAQ title

### DIFF
--- a/packages/docs/learn/faq.mdx
+++ b/packages/docs/learn/faq.mdx
@@ -28,7 +28,7 @@ description: Answers to frequently asked questions about Subframe.
   <Accordion title="How can I get support?">
     Join our [Slack Community](https://join.slack.com/t/subframecommunity/shared_invite/zt-380uma6dv-_lr7_bDLU5DJcoygfUYkeQ) to get fast support from the Subframe team and other members of the community.
   </Accordion>
-  <Accordion title="Where can I find the Terms of Service and Privacy Policy?">
+  <Accordion title="Where can I find the Terms of Service, Privacy Policy, and DPA?">
     You can find our [Terms of Service](https://policies.subframe.com/tos), [Privacy Policy](https://policies.subframe.com/privacy), and [Data Processing Agreement](https://policies.subframe.com/dpa) on our policies site.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Updates the FAQ accordion title from "Where can I find the Terms of Service and Privacy Policy?" to "Where can I find the Terms of Service, Privacy Policy, and DPA?" to match the body text which already mentions the Data Processing Agreement.