### PR TITLE
docs: expand custom CSS page with escape hatch use cases

### DIFF
--- a/packages/docs/learn/design-mode/custom-css.mdx
+++ b/packages/docs/learn/design-mode/custom-css.mdx
@@ -7,7 +7,7 @@ description: Add custom Tailwind classes as an escape hatch for CSS properties n
   <img src="/images/design-mode/tailwind-css-inspector.png" alt="The Tailwind CSS section in the Inspector showing a text input for adding custom classes" />
 </Frame>
 
-If there's a CSS property you need that isn't available in the Inspector, you can add custom Tailwind CSS classes directly to any element. This is useful for properties like positioning, z-index, overflow, and other styles that the visual editor doesn't expose.
+If there's a CSS property you need that isn't available in the Inspector, you can add custom Tailwind CSS classes directly to any element. This is useful for properties like positioning, z-index, overflow, animations, and other styles that the visual editor doesn't expose.
 
 ## Adding custom classes
 
@@ -15,7 +15,7 @@ If there's a CSS property you need that isn't available in the Inspector, you ca
 2. In the Inspector, find **Tailwind CSS** and click **+**
 3. Type or paste a Tailwind class name
 
-<Tip>Use [Ask AI](/learn/ask-ai/making-quick-edits) to add custom classes. For example, ask "make this element position absolute" and it will apply the right Tailwind classes for you.</Tip>
+You can also use [Ask AI](/learn/ask-ai/making-quick-edits) to add custom classes. For example, ask "make this element position absolute" and it will apply the right Tailwind classes for you.
 
 ## Common use cases
 
@@ -26,6 +26,7 @@ Here are some properties you can control with custom Tailwind classes that aren'
 | Absolute positioning | `absolute`, `relative`, `fixed`, `sticky` |
 | Z-index | `z-10`, `z-20`, `z-50` |
 | Overflow | `overflow-hidden`, `overflow-auto`, `overflow-scroll` |
+| Animations | `animate-spin`, `animate-ping`, `animate-pulse`, `animate-bounce` |
 | Pointer events | `pointer-events-none`, `pointer-events-auto` |
 | Opacity | `opacity-50`, `opacity-0` |
 | Cursor | `cursor-pointer`, `cursor-not-allowed` |

--- a/packages/docs/learn/design-mode/custom-css.mdx
+++ b/packages/docs/learn/design-mode/custom-css.mdx
@@ -1,18 +1,40 @@
 ---
 title: Custom CSS
-description: Add custom Tailwind classes to elements.
+description: Add custom Tailwind classes as an escape hatch for CSS properties not available in the Inspector.
 ---
 
 <Frame>
-  <img src="/images/design-mode/tailwind-css-inspector.png" alt="Custom CSS button showing the custom CSS input" />
+  <img src="/images/design-mode/tailwind-css-inspector.png" alt="The Tailwind CSS section in the Inspector showing a text input for adding custom classes" />
 </Frame>
 
-If there's a CSS property you need that isn't available in the Inspector, you can add a custom Tailwind CSS class.
+If there's a CSS property you need that isn't available in the Inspector, you can add custom Tailwind CSS classes directly to any element. This is useful for properties like positioning, z-index, overflow, and other styles that the visual editor doesn't expose.
+
+## Adding custom classes
 
 1. Select an element
-2. Click **+** under **Tailwind CSS** in the Inspector
+2. In the Inspector, find **Tailwind CSS** and click **+**
+3. Type or paste a Tailwind class name
+
+<Tip>Use [Ask AI](/learn/ask-ai/making-quick-edits) to add custom classes. For example, ask "make this element position absolute" and it will apply the right Tailwind classes for you.</Tip>
+
+## Common use cases
+
+Here are some properties you can control with custom Tailwind classes that aren't available in the Inspector:
+
+| Use case | Tailwind classes |
+|----------|-----------------|
+| Absolute positioning | `absolute`, `relative`, `fixed`, `sticky` |
+| Z-index | `z-10`, `z-20`, `z-50` |
+| Overflow | `overflow-hidden`, `overflow-auto`, `overflow-scroll` |
+| Pointer events | `pointer-events-none`, `pointer-events-auto` |
+| Opacity | `opacity-50`, `opacity-0` |
+| Cursor | `cursor-pointer`, `cursor-not-allowed` |
+| Transitions | `transition-all`, `duration-200`, `ease-in-out` |
+| Transforms | `rotate-45`, `scale-110`, `translate-x-2` |
+
+## Tailwind CSS documentation
 
 For a full list of available classes, see the Tailwind CSS documentation:
 
-- [Tailwind CSS v3](https://v3.tailwindcss.com)
-- [Tailwind CSS v4](https://tailwindcss.com)
+- [Tailwind CSS v3 ↗](https://v3.tailwindcss.com)
+- [Tailwind CSS v4 ↗](https://tailwindcss.com)


### PR DESCRIPTION
Expands the custom CSS docs page to better explain that Tailwind classes are an escape hatch for CSS properties not available in the Inspector.

Changes:
- Updated description to frame it as an escape hatch
- Added Ask AI tip for discovering the right classes
- Added common use cases table (positioning, z-index, overflow, pointer-events, etc.)
- Added external link arrows per style guide