### PR TITLE
docs: improve edit_theme and import skill guidance

### DIFF
--- a/plugins/claude/subframe/.claude-plugin/plugin.json
+++ b/plugins/claude/subframe/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "subframe",
   "description": "Design and build UIs with Subframe. Create pixel-perfect React + Tailwind pages using your design system, explore design variations, and implement with business logic.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": {
     "name": "Subframe"
   },

--- a/plugins/claude/subframe/skills/design/SKILL.md
+++ b/plugins/claude/subframe/skills/design/SKILL.md
@@ -150,13 +150,20 @@ Do NOT proactively call `get_variations` after `design_page`. The user reviews a
 
 ### Updating Theme
 
-If the user indicates an issue with their theme and requests changes, use the `edit_theme` tool to update the theme in Subframe. The designs in Subframe will then reflect those changes. `edit_theme` is able to update color, border, corner, and shadow tokens as well as typography. Use `get_theme` to understand the current theme before formulating your changes.
+Use `edit_theme` to update the visual theme of a Subframe project. This tool is designed for **targeted tweaks** and **high-level changes** to an existing theme:
 
-The `description` parameter should describe what changes you want to make to the theme. It can include exact token values if needed.
+- **Targeted tweaks**: Specific adjustments like "make the primary color darker", "increase border radius on all components", "switch the font to Inter", or "make shadows more subtle".
+- **High-level changes**: Broader theme shifts like "switch to a dark theme", "make the design feel more modern and minimal", or "adopt a warm earth-tone palette".
+
+`edit_theme` can update colors, fonts, corners, shadows, and typography tokens. Use `get_theme` to understand the current theme before formulating your changes.
+
+**When NOT to use `edit_theme`:** If the user wants to import or replicate an entire existing design system theme (e.g. "set up our theme to match these design tokens from our codebase"), `edit_theme` is not the right approach. For full theme setup from existing tokens or files, direct the user to the theme import feature in the Subframe UI at `https://app.subframe.com/theme`, where they can upload their theme files directly. For importing a full design system (components + theme), use `/subframe:import` instead — but note that the import feature is only available for certain teams (see the import skill for details).
+
+The `description` parameter should describe what changes you want to make to the theme. It can include exact token values if needed, or it can be a high-level description — the AI will interpret both.
 
 If you are currently working on a page with the user, you should pass that page information into the `edit_theme` tool call.
 
 If a page is provided, the tool will return a URL where the user can review and apply the theme changes.
 If no page is provided, the tool will return a URL where the user can see the updated project theme. The user cannot review the theme changes prior to application in this case, so it is best to provide a page identifier if any is available.
 
-**Important:** The theme affects all pages in the project, so always make the user confirm that they want to update the whole project before using `edit_theme`. If the user only wants to update a particular page, you should use `edit_page` instead.
+**Important:** The theme affects all pages and components in the project, so always make the user confirm that they want to update the whole project before using `edit_theme`. If the user only wants to change the styling of a particular page (not the project-wide theme), use `edit_page` instead.

--- a/plugins/claude/subframe/skills/import/SKILL.md
+++ b/plugins/claude/subframe/skills/import/SKILL.md
@@ -5,7 +5,7 @@ description: Import an existing design system into Subframe. Discovers component
 
 Import an existing design system into Subframe by discovering files on disk, building a manifest, and uploading via the CLI.
 
-> **Availability:** The design system import feature is currently only available for select teams. If the CLI returns an error like `"Design system import is not enabled for this team"`, this means the feature has not been enabled for the user's team. Direct the user to contact [support@subframe.com](mailto:support@subframe.com) to request access. Do not retry or troubleshoot further — this is an access gate, not a bug.
+> **Availability:** The design system import feature is currently only available for select teams. If the CLI returns an error like `"Design system import is not enabled for this team"`, this means the feature has not been enabled for the user's team. Direct the user to [request access here](https://tally.so/r/3jv511). Do not retry or troubleshoot further — this is an access gate, not a bug.
 
 **Goal state**: All design system files are uploaded to Subframe for processing.
 
@@ -137,7 +137,7 @@ If any files are missing the CLI will abort with an error. Otherwise, report to 
 ## Error Handling
 
 - If the CLI exits with an error, show the full error output to the user
-- **Access errors**: If the CLI returns `"Design system import is not enabled for this team"`, this is not a bug or auth issue — the import feature is only available for certain teams. Let the user know and suggest reaching out to [support@subframe.com](mailto:support@subframe.com) to request access. Do not retry with a new token or attempt workarounds.
+- **Access errors**: If the CLI returns `"Design system import is not enabled for this team"`, this is not a bug or auth issue — the import feature is only available for certain teams. Let the user know and direct them to [request access here](https://tally.so/r/3jv511). Do not retry with a new token or attempt workarounds.
 - Auth errors: try generating a new token with `generate_auth_token`, or suggest the user re-authenticate at `https://app.subframe.com/cli/auth`
 - Network errors: suggest checking connectivity and retrying
 - If the manifest JSON is malformed, fix it and retry — don't ask the user to debug JSON

--- a/plugins/claude/subframe/skills/import/SKILL.md
+++ b/plugins/claude/subframe/skills/import/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: import
-description: Import an existing design system into Subframe. Discovers component files, stories, and CSS/Tailwind config, then uploads everything to Subframe for processing.
+description: Import an existing design system into Subframe. Discovers component files, stories, and CSS/Tailwind config, then uploads everything to Subframe for processing. This feature is only available for certain teams.
 ---
 
 Import an existing design system into Subframe by discovering files on disk, building a manifest, and uploading via the CLI.
+
+> **Availability:** The design system import feature is currently only available for select teams. If the CLI returns an error like `"Design system import is not enabled for this team"`, this means the feature has not been enabled for the user's team. Direct the user to contact [support@subframe.com](mailto:support@subframe.com) to request access. Do not retry or troubleshoot further — this is an access gate, not a bug.
 
 **Goal state**: All design system files are uploaded to Subframe for processing.
 
@@ -135,6 +137,7 @@ If any files are missing the CLI will abort with an error. Otherwise, report to 
 ## Error Handling
 
 - If the CLI exits with an error, show the full error output to the user
+- **Access errors**: If the CLI returns `"Design system import is not enabled for this team"`, this is not a bug or auth issue — the import feature is only available for certain teams. Let the user know and suggest reaching out to [support@subframe.com](mailto:support@subframe.com) to request access. Do not retry with a new token or attempt workarounds.
 - Auth errors: try generating a new token with `generate_auth_token`, or suggest the user re-authenticate at `https://app.subframe.com/cli/auth`
 - Network errors: suggest checking connectivity and retrying
 - If the manifest JSON is malformed, fix it and retry — don't ask the user to debug JSON


### PR DESCRIPTION
## Summary

Based on user feedback from Intercom (Tim Schwartz), this PR improves the Claude plugin skill documentation to help agents (and humans) better understand when to use the various tools.

## Changes

### `design/SKILL.md` — edit_theme guidance
- Rewrote the "Updating Theme" section to clearly explain that `edit_theme` is for **targeted tweaks** (e.g. "make primary color darker") and **high-level changes** (e.g. "switch to dark theme")
- Added explicit "When NOT to use" guidance: if the user wants to import/replicate an entire existing design system theme from their codebase, `edit_theme` is not the right tool
- Points users to the Subframe UI theme import at `https://app.subframe.com/theme` for full theme setup
- Cross-references `/subframe:import` for full design system imports

### `import/SKILL.md` — availability notice
- Added prominent availability callout at the top: import is only available for select teams
- Includes the exact error message (`"Design system import is not enabled for this team"`) so agents can pattern-match and respond correctly
- Clear guidance: this is an access gate, not a bug — don't retry, don't troubleshoot, contact support@subframe.com
- Updated error handling section with the same guidance
- Updated skill description in frontmatter to mention team availability

## Context

Tim was trying to set up his theme via MCP and hit two issues:
1. Agents kept trying `edit_theme` for full theme import (not what it's designed for)
2. The `/subframe:import` CLI returned "Design system import is not enabled for this team" with no helpful guidance from agents

These docs changes address both issues at the skill/instruction level so agents handle them correctly going forward.

> **Note:** The MCP tool descriptions in `design-tool-app` (e.g. the `edit_theme` tool's `description` field) could also benefit from similar clarification, but that's in a separate repo. This PR covers the Claude plugin skill docs only.