### PR TITLE
docs: expand inspiration workflow with MCP tool guidance

### DIFF
--- a/plugins/claude/subframe/.claude-plugin/plugin.json
+++ b/plugins/claude/subframe/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "subframe",
   "description": "Design and build UIs with Subframe. Create pixel-perfect React + Tailwind pages using your design system, explore design variations, and implement with business logic.",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": {
     "name": "Subframe"
   },

--- a/plugins/claude/subframe/skills/develop/SKILL.md
+++ b/plugins/claude/subframe/skills/develop/SKILL.md
@@ -38,10 +38,10 @@ If the current directory has a `package.json` but no `.subframe/` folder, ask th
 
 Use this workflow when the user chose to use the design as inspiration in an existing non-Subframe project.
 
-1. **Fetch the design** - Use `get_page_info` with the URL, ID, or name to get the design's layout and structure. Use other available Subframe MCP tools as needed to get additional context (e.g., `get_component_info` to understand a component's props, `get_theme` to check theme values).
-2. **Study existing patterns** - Look at the project's existing components, styles, and conventions
-3. **Create the page** - Implement the design using the project's existing UI framework, mapping Subframe components to their equivalents in the codebase (e.g., Subframe `Button` → the project's own button component)
-4. **Add business logic** - Data fetching, forms, events, loading/error states
+1. **Fetch the design** — Use `get_page_info` with the URL, ID, or name to get the page's layout and structure. If you encounter Subframe components or tokens you're unfamiliar with, use `get_component_info` to understand a component's props and behavior, or `get_theme` to see the Subframe project's design tokens (colors, fonts, spacing, shadows).
+2. **Study existing patterns** — Look at the codebase's existing components, styles, and conventions. Identify local equivalents for Subframe components used in the design.
+3. **Create the page** — Implement the design using the codebase's existing UI framework, translating the Subframe layout and component structure into local components and styling.
+4. **Add business logic** — Data fetching, forms, events, loading/error states.
 
 ## Fetching Designs
 


### PR DESCRIPTION
## Summary

Expands the "Inspiration Workflow" section in the develop skill to give agents more concrete guidance on using MCP tools to understand Subframe designs before translating them into a project's own UI framework.

## Changes

### `develop/SKILL.md` — Inspiration Workflow

The existing workflow had a brief mention of `get_component_info` and `get_theme` in passing. This update makes them explicit steps:

- **`get_component_info`** — Fetch full details for each Subframe component used in the page to understand props, variants, and slots before finding local equivalents
- **`get_theme`** — Fetch design tokens (colors, fonts, spacing, shadows) to map them to the project's own styling system
- **`list_components`** — Get an overview of the full Subframe design system vocabulary
- Clearer step-by-step: understand the design system → study local patterns → translate with fidelity

### Plugin version bump
- 1.0.10 → 1.0.11

> **Note:** If PR #134 (edit_theme/import guidance) merges first, there will be a version conflict on plugin.json — just bump to 1.0.12 when resolving.