### PR TITLE
docs: update dark mode guide for native theme support

### DIFF
--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -1,103 +1,166 @@
 ---
 title: Dark mode
-description: Add dark mode to your project using Subframe's built-in theme support
+description: Setting up dark mode using CSS variables
 ---
 
-import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
+Subframe doesn't support dark mode out-of-the-box, but you can easily implement it in your codebase using CSS variables. This guide shows you how to set up dark mode using CSS variables and Tailwind's dark mode support.
 
-Subframe has built-in dark mode support. Enable it in your theme to define light and dark values side by side, then sync to get a fully configured Tailwind setup.
+## Prerequisites
 
-## Enable dark mode
+Before setting up dark mode, ensure you have:
 
-1. Open **Theme** in the top navigation
-2. In the Colors section, click **Add dark mode** (or toggle dark mode on from the theme presets)
-3. Each token now shows light and dark values — edit the dark values to define your dark palette
+- [Installed Subframe](/installation) in your project
+- [Synced your components and theme](/concepts/syncing-components) to your codebase
 
-<Tip>
-  Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
-</Tip>
+## How it works
 
-To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
+1. Configure Tailwind to use CSS variables instead of hardcoded colors
+2. Define light mode colors from your Subframe theme as CSS variables
+3. Define dark mode color overrides under an `html.dark` selector
+4. Toggle between modes by adding/removing the `dark` class on the HTML element
 
-## How the generated code works
+This keeps your Subframe workflow unchanged while enabling dark mode in your application.
 
-When dark mode is enabled, Subframe generates theme tokens as CSS variables so light and dark values can switch at runtime.
+## Step 1: Configure Tailwind for CSS variables
 
 <Tabs>
 <Tab title="Tailwind v3">
 
-The CLI syncs two files:
+Modify your `tailwind.config.js` to use CSS variables.
 
-- **`tailwind.config.js`** — references CSS variables instead of hardcoded values, with `darkMode: 'selector'` enabled
-- **`theme.css`** — defines `:root` variables for light mode and `.dark` overrides for dark mode
+<Note>Add `// @subframe/sync-disable` at the top to prevent Subframe from overwriting your changes.</Note>
 
-```js tailwind.config.js
+```js tailwind.config.js {1, 3}
+// @subframe/sync-disable
 module.exports = {
-  darkMode: 'selector',
+  darkMode: "selector", // Enable class-based dark mode
   theme: {
     extend: {
       colors: {
-        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
-        // ... all color tokens as CSS variable references
+        brand: {
+          50: "var(--brand-50)",
+          100: "var(--brand-100)",
+          // ... rest of your brand colors as CSS variables
+        },
+        neutral: {
+          0: "var(--neutral-0)",
+          50: "var(--neutral-50)",
+          // ... rest of your neutral colors
+        },
+        // Continue for error, warning, success, etc.
+        "brand-primary": "var(--brand-primary)",
+        "default-font": "var(--default-font)",
+        "subtext-color": "var(--subtext-color)",
+        "neutral-border": "var(--neutral-border)",
+        white: "var(--white)",
+        "default-background": "var(--default-background)",
       },
     },
   },
 }
 ```
 
-```css theme.css
-:root {
-  --color-brand-primary: 26 26 26;
-  --color-default-background: 252 252 252;
-  /* ... light mode values */
-}
-
-.dark {
-  --color-brand-primary: 212 212 212;
-  --color-default-background: 10 10 10;
-  /* ... dark mode overrides */
-}
-```
-
-Import `theme.css` in your global stylesheet or entry point:
-
-```css globals.css
-@import "./subframe/theme.css";
-```
+<Note>
+  Find your theme configuration in the [Theme
+  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV3).
+</Note>
 
 </Tab>
 <Tab title="Tailwind v4">
 
-The generated `theme.css` includes a `@custom-variant` for dark mode and a `.dark` block with overrides:
+Modify your `theme.css` to use CSS variables and add the dark mode custom variant:
 
-```css theme.css
-@custom-variant dark (&:where(.dark, .dark *));
-
+```css theme.css {1-3, 295}
 @theme {
-  --color-brand-primary: rgb(26 26 26);
-  --color-default-background: rgb(252 252 252);
-  /* ... light mode values */
+  /* Replace hardcoded colors with CSS variables */
+  --color-brand-50: var(--brand-50);
+  --color-brand-100: var(--brand-100);
+  /* ... continue for all colors */
+
+  /* Keep fonts, shadows, borders, spacing as-is */
 }
 
-.dark {
-  --color-brand-primary: rgb(212 212 212);
-  --color-default-background: rgb(10 10 10);
-  /* ... dark mode overrides */
-}
+/* Enable dark mode */
+@custom-variant dark (&:where(.dark, .dark *));
 ```
+
+<Note>
+  Find your theme.css in the [Theme
+  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV4).
+</Note>
 
 </Tab>
 </Tabs>
 
-## Sync to code
+## Step 2: Create CSS variables file
 
-Run the CLI to sync your theme (including dark mode) to your codebase:
+Create a `variables.css` file that defines CSS variables for both light and dark modes:
 
-<CliSyncAllCommand />
+```css variables.css
+/* Light mode */
 
-## Enable dark mode in your app
+html {
+  --brand-50: rgb(250, 250, 250);
+  --brand-100: rgb(245, 245, 245);
+  /* ... rest of brand colors */
 
-To activate dark mode, set the `dark` class on the `<html>` element. Here are a few ways to accomplish that:
+  --neutral-0: rgb(255, 255, 255);
+  --neutral-50: rgb(247, 247, 247);
+  /* ... rest of neutral colors */
+
+  /* Semantic colors */
+  --brand-primary: rgb(26, 26, 26);
+  --default-font: rgb(41, 41, 41);
+  --subtext-color: rgb(117, 117, 117);
+  --neutral-border: rgb(240, 240, 240);
+  --white: rgb(255, 255, 255);
+  --default-background: rgb(252, 252, 252);
+}
+
+/* Dark mode */
+
+html.dark {
+  --brand-50: rgb(23, 23, 23);
+  --brand-100: rgb(38, 38, 38);
+  /* ... inverted brand colors (light becomes dark) */
+
+  --neutral-0: rgb(10, 10, 10);
+  --neutral-50: rgb(23, 23, 23);
+  /* ... inverted neutral colors */
+
+  /* Dark semantic colors */
+  --brand-primary: rgb(212, 212, 212);
+  --default-font: rgb(250, 250, 250);
+  --subtext-color: rgb(163, 163, 163);
+  --neutral-border: rgb(64, 64, 64);
+  --white: rgb(10, 10, 10);
+  --default-background: rgb(10, 10, 10);
+}
+```
+
+<Tip>
+  Dark mode colors typically invert the scale: light mode's `--brand-50` (lightest) becomes dark mode's `--brand-900`
+  (darkest), and vice versa.
+</Tip>
+
+## Step 3: Import variables globally
+
+Import your `variables.css` in your global CSS file (typically `index.css`, `globals.css`, or `App.css` depending on framework):
+
+```css globals.css
+@import "./variables.css";
+@import "tailwindcss";
+```
+
+Or import directly in your entry point:
+
+```tsx main.tsx
+import "./variables.css"
+```
+
+## Step 4: Toggle dark mode
+
+Add or remove the `dark` class on the `<html>` element to switch themes.
 
 ### Next.js with next-themes
 

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -1,103 +1,166 @@
 ---
 title: Dark mode
-description: Add dark mode to your project using Subframe's built-in theme support
+description: Setting up dark mode using CSS variables
 ---
 
-import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
+Subframe doesn't support dark mode out-of-the-box, but you can easily implement it in your codebase using CSS variables. This guide shows you how to set up dark mode using CSS variables and Tailwind's dark mode support.
 
-Subframe has built-in dark mode support. Enable it in your theme to define light and dark values side by side, then sync to get a fully configured Tailwind setup.
+## Prerequisites
 
-## Enable dark mode
+Before setting up dark mode, ensure you have:
 
-1. Open **Theme** in the top navigation
-2. In the Colors section, click **Add dark mode**
-3. Each token now shows light and dark values — edit the dark values to define your dark palette
+- [Installed Subframe](/installation) in your project
+- [Synced your components and theme](/concepts/syncing-components) to your codebase
 
-<Tip>
-  Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
-</Tip>
+## How it works
 
-To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
+1. Configure Tailwind to use CSS variables instead of hardcoded colors
+2. Define light mode colors from your Subframe theme as CSS variables
+3. Define dark mode color overrides under an `html.dark` selector
+4. Toggle between modes by adding/removing the `dark` class on the HTML element
 
-## How the generated code works
+This keeps your Subframe workflow unchanged while enabling dark mode in your application.
 
-When dark mode is enabled, Subframe generates theme tokens as CSS variables so light and dark values can switch at runtime.
+## Step 1: Configure Tailwind for CSS variables
 
 <Tabs>
 <Tab title="Tailwind v3">
 
-The CLI syncs two files:
+Modify your `tailwind.config.js` to use CSS variables.
 
-- **`tailwind.config.js`** — references CSS variables instead of hardcoded values, with `darkMode: 'selector'` enabled
-- **`theme.css`** — defines `:root` variables for light mode and `.dark` overrides for dark mode
+<Note>Add `// @subframe/sync-disable` at the top to prevent Subframe from overwriting your changes.</Note>
 
-```js tailwind.config.js
+```js tailwind.config.js {1, 3}
+// @subframe/sync-disable
 module.exports = {
-  darkMode: 'selector',
+  darkMode: "selector", // Enable class-based dark mode
   theme: {
     extend: {
       colors: {
-        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
-        // ... all color tokens as CSS variable references
+        brand: {
+          50: "var(--brand-50)",
+          100: "var(--brand-100)",
+          // ... rest of your brand colors as CSS variables
+        },
+        neutral: {
+          0: "var(--neutral-0)",
+          50: "var(--neutral-50)",
+          // ... rest of your neutral colors
+        },
+        // Continue for error, warning, success, etc.
+        "brand-primary": "var(--brand-primary)",
+        "default-font": "var(--default-font)",
+        "subtext-color": "var(--subtext-color)",
+        "neutral-border": "var(--neutral-border)",
+        white: "var(--white)",
+        "default-background": "var(--default-background)",
       },
     },
   },
 }
 ```
 
-```css theme.css
-:root {
-  --color-brand-primary: 26 26 26;
-  --color-default-background: 252 252 252;
-  /* ... light mode values */
-}
-
-.dark {
-  --color-brand-primary: 212 212 212;
-  --color-default-background: 10 10 10;
-  /* ... dark mode overrides */
-}
-```
-
-Import `theme.css` in your global stylesheet or entry point:
-
-```css globals.css
-@import "./subframe/theme.css";
-```
+<Note>
+  Find your theme configuration in the [Theme
+  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV3).
+</Note>
 
 </Tab>
 <Tab title="Tailwind v4">
 
-The generated `theme.css` includes a `@custom-variant` for dark mode and a `.dark` block with overrides:
+Modify your `theme.css` to use CSS variables and add the dark mode custom variant:
 
-```css theme.css
-@custom-variant dark (&:where(.dark, .dark *));
-
+```css theme.css {1-3, 295}
 @theme {
-  --color-brand-primary: rgb(26 26 26);
-  --color-default-background: rgb(252 252 252);
-  /* ... light mode values */
+  /* Replace hardcoded colors with CSS variables */
+  --color-brand-50: var(--brand-50);
+  --color-brand-100: var(--brand-100);
+  /* ... continue for all colors */
+
+  /* Keep fonts, shadows, borders, spacing as-is */
 }
 
-.dark {
-  --color-brand-primary: rgb(212 212 212);
-  --color-default-background: rgb(10 10 10);
-  /* ... dark mode overrides */
-}
+/* Enable dark mode */
+@custom-variant dark (&:where(.dark, .dark *));
 ```
+
+<Note>
+  Find your theme.css in the [Theme
+  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV4).
+</Note>
 
 </Tab>
 </Tabs>
 
-## Sync to code
+## Step 2: Create CSS variables file
 
-Run the CLI to sync your theme (including dark mode) to your codebase:
+Create a `variables.css` file that defines CSS variables for both light and dark modes:
 
-<CliSyncAllCommand />
+```css variables.css
+/* Light mode */
 
-## Enable dark mode in your app
+html {
+  --brand-50: rgb(250, 250, 250);
+  --brand-100: rgb(245, 245, 245);
+  /* ... rest of brand colors */
 
-To activate dark mode, set the `dark` class on the `<html>` element. Here are a few ways to accomplish that:
+  --neutral-0: rgb(255, 255, 255);
+  --neutral-50: rgb(247, 247, 247);
+  /* ... rest of neutral colors */
+
+  /* Semantic colors */
+  --brand-primary: rgb(26, 26, 26);
+  --default-font: rgb(41, 41, 41);
+  --subtext-color: rgb(117, 117, 117);
+  --neutral-border: rgb(240, 240, 240);
+  --white: rgb(255, 255, 255);
+  --default-background: rgb(252, 252, 252);
+}
+
+/* Dark mode */
+
+html.dark {
+  --brand-50: rgb(23, 23, 23);
+  --brand-100: rgb(38, 38, 38);
+  /* ... inverted brand colors (light becomes dark) */
+
+  --neutral-0: rgb(10, 10, 10);
+  --neutral-50: rgb(23, 23, 23);
+  /* ... inverted neutral colors */
+
+  /* Dark semantic colors */
+  --brand-primary: rgb(212, 212, 212);
+  --default-font: rgb(250, 250, 250);
+  --subtext-color: rgb(163, 163, 163);
+  --neutral-border: rgb(64, 64, 64);
+  --white: rgb(10, 10, 10);
+  --default-background: rgb(10, 10, 10);
+}
+```
+
+<Tip>
+  Dark mode colors typically invert the scale: light mode's `--brand-50` (lightest) becomes dark mode's `--brand-900`
+  (darkest), and vice versa.
+</Tip>
+
+## Step 3: Import variables globally
+
+Import your `variables.css` in your global CSS file (typically `index.css`, `globals.css`, or `App.css` depending on framework):
+
+```css globals.css
+@import "./variables.css";
+@import "tailwindcss";
+```
+
+Or import directly in your entry point:
+
+```tsx main.tsx
+import "./variables.css"
+```
+
+## Step 4: Toggle dark mode
+
+Add or remove the `dark` class on the `<html>` element to switch themes.
 
 ### Next.js with next-themes
 

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -1,166 +1,103 @@
 ---
 title: Dark mode
-description: Setting up dark mode using CSS variables
+description: Add dark mode to your project using Subframe's built-in theme support
 ---
 
-Subframe doesn't support dark mode out-of-the-box, but you can easily implement it in your codebase using CSS variables. This guide shows you how to set up dark mode using CSS variables and Tailwind's dark mode support.
+import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
 
-## Prerequisites
+Subframe has built-in dark mode support. Enable it in your theme to define light and dark values side by side, then sync to get a fully configured Tailwind setup.
 
-Before setting up dark mode, ensure you have:
+## Enable dark mode
 
-- [Installed Subframe](/installation) in your project
-- [Synced your components and theme](/concepts/syncing-components) to your codebase
+1. Open **Theme** in the top navigation
+2. In the Colors section, click **Add dark mode**
+3. Each token now shows light and dark values — edit the dark values to define your dark palette
 
-## How it works
+<Tip>
+  Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
+</Tip>
 
-1. Configure Tailwind to use CSS variables instead of hardcoded colors
-2. Define light mode colors from your Subframe theme as CSS variables
-3. Define dark mode color overrides under an `html.dark` selector
-4. Toggle between modes by adding/removing the `dark` class on the HTML element
+To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
 
-This keeps your Subframe workflow unchanged while enabling dark mode in your application.
+## How the generated code works
 
-## Step 1: Configure Tailwind for CSS variables
+When dark mode is enabled, Subframe generates theme tokens as CSS variables so light and dark values can switch at runtime.
 
 <Tabs>
 <Tab title="Tailwind v3">
 
-Modify your `tailwind.config.js` to use CSS variables.
+The CLI syncs two files:
 
-<Note>Add `// @subframe/sync-disable` at the top to prevent Subframe from overwriting your changes.</Note>
+- **`tailwind.config.js`** — references CSS variables instead of hardcoded values, with `darkMode: 'selector'` enabled
+- **`theme.css`** — defines `:root` variables for light mode and `.dark` overrides for dark mode
 
-```js tailwind.config.js {1, 3}
-// @subframe/sync-disable
+```js tailwind.config.js
 module.exports = {
-  darkMode: "selector", // Enable class-based dark mode
+  darkMode: 'selector',
   theme: {
     extend: {
       colors: {
-        brand: {
-          50: "var(--brand-50)",
-          100: "var(--brand-100)",
-          // ... rest of your brand colors as CSS variables
-        },
-        neutral: {
-          0: "var(--neutral-0)",
-          50: "var(--neutral-50)",
-          // ... rest of your neutral colors
-        },
-        // Continue for error, warning, success, etc.
-        "brand-primary": "var(--brand-primary)",
-        "default-font": "var(--default-font)",
-        "subtext-color": "var(--subtext-color)",
-        "neutral-border": "var(--neutral-border)",
-        white: "var(--white)",
-        "default-background": "var(--default-background)",
+        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
+        // ... all color tokens as CSS variable references
       },
     },
   },
 }
 ```
 
-<Note>
-  Find your theme configuration in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV3).
-</Note>
+```css theme.css
+:root {
+  --color-brand-primary: 26 26 26;
+  --color-default-background: 252 252 252;
+  /* ... light mode values */
+}
+
+.dark {
+  --color-brand-primary: 212 212 212;
+  --color-default-background: 10 10 10;
+  /* ... dark mode overrides */
+}
+```
+
+Import `theme.css` in your global stylesheet or entry point:
+
+```css globals.css
+@import "./subframe/theme.css";
+```
 
 </Tab>
 <Tab title="Tailwind v4">
 
-Modify your `theme.css` to use CSS variables and add the dark mode custom variant:
+The generated `theme.css` includes a `@custom-variant` for dark mode and a `.dark` block with overrides:
 
-```css theme.css {1-3, 295}
+```css theme.css
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
-  /* Replace hardcoded colors with CSS variables */
-  --color-brand-50: var(--brand-50);
-  --color-brand-100: var(--brand-100);
-  /* ... continue for all colors */
-
-  /* Keep fonts, shadows, borders, spacing as-is */
+  --color-brand-primary: rgb(26 26 26);
+  --color-default-background: rgb(252 252 252);
+  /* ... light mode values */
 }
 
-/* Enable dark mode */
-@custom-variant dark (&:where(.dark, .dark *));
+.dark {
+  --color-brand-primary: rgb(212 212 212);
+  --color-default-background: rgb(10 10 10);
+  /* ... dark mode overrides */
+}
 ```
-
-<Note>
-  Find your theme.css in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV4).
-</Note>
 
 </Tab>
 </Tabs>
 
-## Step 2: Create CSS variables file
+## Sync to code
 
-Create a `variables.css` file that defines CSS variables for both light and dark modes:
+Run the CLI to sync your theme (including dark mode) to your codebase:
 
-```css variables.css
-/* Light mode */
+<CliSyncAllCommand />
 
-html {
-  --brand-50: rgb(250, 250, 250);
-  --brand-100: rgb(245, 245, 245);
-  /* ... rest of brand colors */
+## Enable dark mode in your app
 
-  --neutral-0: rgb(255, 255, 255);
-  --neutral-50: rgb(247, 247, 247);
-  /* ... rest of neutral colors */
-
-  /* Semantic colors */
-  --brand-primary: rgb(26, 26, 26);
-  --default-font: rgb(41, 41, 41);
-  --subtext-color: rgb(117, 117, 117);
-  --neutral-border: rgb(240, 240, 240);
-  --white: rgb(255, 255, 255);
-  --default-background: rgb(252, 252, 252);
-}
-
-/* Dark mode */
-
-html.dark {
-  --brand-50: rgb(23, 23, 23);
-  --brand-100: rgb(38, 38, 38);
-  /* ... inverted brand colors (light becomes dark) */
-
-  --neutral-0: rgb(10, 10, 10);
-  --neutral-50: rgb(23, 23, 23);
-  /* ... inverted neutral colors */
-
-  /* Dark semantic colors */
-  --brand-primary: rgb(212, 212, 212);
-  --default-font: rgb(250, 250, 250);
-  --subtext-color: rgb(163, 163, 163);
-  --neutral-border: rgb(64, 64, 64);
-  --white: rgb(10, 10, 10);
-  --default-background: rgb(10, 10, 10);
-}
-```
-
-<Tip>
-  Dark mode colors typically invert the scale: light mode's `--brand-50` (lightest) becomes dark mode's `--brand-900`
-  (darkest), and vice versa.
-</Tip>
-
-## Step 3: Import variables globally
-
-Import your `variables.css` in your global CSS file (typically `index.css`, `globals.css`, or `App.css` depending on framework):
-
-```css globals.css
-@import "./variables.css";
-@import "tailwindcss";
-```
-
-Or import directly in your entry point:
-
-```tsx main.tsx
-import "./variables.css"
-```
-
-## Step 4: Toggle dark mode
-
-Add or remove the `dark` class on the `<html>` element to switch themes.
+To activate dark mode, set the `dark` class on the `<html>` element. Here are a few ways to accomplish that:
 
 ### Next.js with next-themes
 

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -1,166 +1,103 @@
 ---
 title: Dark mode
-description: Setting up dark mode using CSS variables
+description: Add dark mode to your project using Subframe's built-in theme support
 ---
 
-Subframe doesn't support dark mode out-of-the-box, but you can easily implement it in your codebase using CSS variables. This guide shows you how to set up dark mode using CSS variables and Tailwind's dark mode support.
+import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
 
-## Prerequisites
+Subframe has built-in dark mode support. Enable it in your theme to define light and dark color values side by side, then export or sync to get a fully configured Tailwind setup.
 
-Before setting up dark mode, ensure you have:
+## Enable dark mode
 
-- [Installed Subframe](/installation) in your project
-- [Synced your components and theme](/concepts/syncing-components) to your codebase
+1. Open **Theme** in the top navigation
+2. In the Colors section, click **Add dark mode** (or toggle dark mode on from the theme presets)
+3. Each color token now shows light and dark values — edit the dark values to define your dark palette
 
-## How it works
+<Tip>
+  Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
+</Tip>
 
-1. Configure Tailwind to use CSS variables instead of hardcoded colors
-2. Define light mode colors from your Subframe theme as CSS variables
-3. Define dark mode color overrides under an `html.dark` selector
-4. Toggle between modes by adding/removing the `dark` class on the HTML element
+To remove dark mode, click **⋯** in the Colors section and select **Remove dark mode**. This deletes all dark color overrides. You can undo this using version history.
 
-This keeps your Subframe workflow unchanged while enabling dark mode in your application.
+## How the generated code works
 
-## Step 1: Configure Tailwind for CSS variables
+When dark mode is enabled, Subframe generates theme tokens as CSS variables so light and dark values can switch at runtime.
 
 <Tabs>
 <Tab title="Tailwind v3">
 
-Modify your `tailwind.config.js` to use CSS variables.
+The CLI syncs two files:
 
-<Note>Add `// @subframe/sync-disable` at the top to prevent Subframe from overwriting your changes.</Note>
+- **`tailwind.config.js`** — references CSS variables instead of hardcoded values, with `darkMode: 'selector'` enabled
+- **`theme.css`** — defines `:root` variables for light mode and `.dark` overrides for dark mode
 
-```js tailwind.config.js {1, 3}
-// @subframe/sync-disable
+```js tailwind.config.js
 module.exports = {
-  darkMode: "selector", // Enable class-based dark mode
+  darkMode: 'selector',
   theme: {
     extend: {
       colors: {
-        brand: {
-          50: "var(--brand-50)",
-          100: "var(--brand-100)",
-          // ... rest of your brand colors as CSS variables
-        },
-        neutral: {
-          0: "var(--neutral-0)",
-          50: "var(--neutral-50)",
-          // ... rest of your neutral colors
-        },
-        // Continue for error, warning, success, etc.
-        "brand-primary": "var(--brand-primary)",
-        "default-font": "var(--default-font)",
-        "subtext-color": "var(--subtext-color)",
-        "neutral-border": "var(--neutral-border)",
-        white: "var(--white)",
-        "default-background": "var(--default-background)",
+        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
+        // ... all color tokens as CSS variable references
       },
     },
   },
 }
 ```
 
-<Note>
-  Find your theme configuration in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV3).
-</Note>
+```css theme.css
+:root {
+  --color-brand-primary: 26 26 26;
+  --color-default-background: 252 252 252;
+  /* ... light mode values */
+}
+
+.dark {
+  --color-brand-primary: 212 212 212;
+  --color-default-background: 10 10 10;
+  /* ... dark mode overrides */
+}
+```
+
+Import `theme.css` in your global stylesheet or entry point:
+
+```css globals.css
+@import "./subframe/theme.css";
+```
 
 </Tab>
 <Tab title="Tailwind v4">
 
-Modify your `theme.css` to use CSS variables and add the dark mode custom variant:
+The generated `theme.css` includes a `@custom-variant` for dark mode and a `.dark` block with overrides:
 
-```css theme.css {1-3, 295}
+```css theme.css
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
-  /* Replace hardcoded colors with CSS variables */
-  --color-brand-50: var(--brand-50);
-  --color-brand-100: var(--brand-100);
-  /* ... continue for all colors */
-
-  /* Keep fonts, shadows, borders, spacing as-is */
+  --color-brand-primary: rgb(26 26 26);
+  --color-default-background: rgb(252 252 252);
+  /* ... light mode values */
 }
 
-/* Enable dark mode */
-@custom-variant dark (&:where(.dark, .dark *));
+.dark {
+  --color-brand-primary: rgb(212 212 212);
+  --color-default-background: rgb(10 10 10);
+  /* ... dark mode overrides */
+}
 ```
-
-<Note>
-  Find your theme.css in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV4).
-</Note>
 
 </Tab>
 </Tabs>
 
-## Step 2: Create CSS variables file
+## Sync to code
 
-Create a `variables.css` file that defines CSS variables for both light and dark modes:
+Run the CLI to sync your theme (including dark mode) to your codebase:
 
-```css variables.css
-/* Light mode */
+<CliSyncAllCommand />
 
-html {
-  --brand-50: rgb(250, 250, 250);
-  --brand-100: rgb(245, 245, 245);
-  /* ... rest of brand colors */
+## Toggle dark mode in your app
 
-  --neutral-0: rgb(255, 255, 255);
-  --neutral-50: rgb(247, 247, 247);
-  /* ... rest of neutral colors */
-
-  /* Semantic colors */
-  --brand-primary: rgb(26, 26, 26);
-  --default-font: rgb(41, 41, 41);
-  --subtext-color: rgb(117, 117, 117);
-  --neutral-border: rgb(240, 240, 240);
-  --white: rgb(255, 255, 255);
-  --default-background: rgb(252, 252, 252);
-}
-
-/* Dark mode */
-
-html.dark {
-  --brand-50: rgb(23, 23, 23);
-  --brand-100: rgb(38, 38, 38);
-  /* ... inverted brand colors (light becomes dark) */
-
-  --neutral-0: rgb(10, 10, 10);
-  --neutral-50: rgb(23, 23, 23);
-  /* ... inverted neutral colors */
-
-  /* Dark semantic colors */
-  --brand-primary: rgb(212, 212, 212);
-  --default-font: rgb(250, 250, 250);
-  --subtext-color: rgb(163, 163, 163);
-  --neutral-border: rgb(64, 64, 64);
-  --white: rgb(10, 10, 10);
-  --default-background: rgb(10, 10, 10);
-}
-```
-
-<Tip>
-  Dark mode colors typically invert the scale: light mode's `--brand-50` (lightest) becomes dark mode's `--brand-900`
-  (darkest), and vice versa.
-</Tip>
-
-## Step 3: Import variables globally
-
-Import your `variables.css` in your global CSS file (typically `index.css`, `globals.css`, or `App.css` depending on framework):
-
-```css globals.css
-@import "./variables.css";
-@import "tailwindcss";
-```
-
-Or import directly in your entry point:
-
-```tsx main.tsx
-import "./variables.css"
-```
-
-## Step 4: Toggle dark mode
-
-Add or remove the `dark` class on the `<html>` element to switch themes.
+Add or remove the `dark` class on the `<html>` element to switch between light and dark mode.
 
 ### Next.js with next-themes
 
@@ -202,7 +139,7 @@ export function ThemeProvider({ children }) {
 
   const toggleTheme = () => setTheme(theme === "light" ? "dark" : "light")
 
-  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+  return <ThemeContext.Provider value=undefined>{children}</ThemeContext.Provider>
 }
 
 export const useTheme = () => useContext(ThemeContext)

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -1,166 +1,104 @@
 ---
 title: Dark mode
-description: Setting up dark mode using CSS variables
+description: Add dark mode to your project using Subframe's built-in theme support
 ---
 
-Subframe doesn't support dark mode out-of-the-box, but you can easily implement it in your codebase using CSS variables. This guide shows you how to set up dark mode using CSS variables and Tailwind's dark mode support.
+import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
 
-## Prerequisites
+Subframe has built-in dark mode support. Enable it in your theme to define light and dark values side by side, then sync to get a fully configured Tailwind setup.
 
-Before setting up dark mode, ensure you have:
+## Enable dark mode
 
-- [Installed Subframe](/installation) in your project
-- [Synced your components and theme](/concepts/syncing-components) to your codebase
+1. Open **Theme** in the top navigation
+2. In the Colors section, click **Add dark mode**
+3. Each token now shows light and dark values — edit the dark values to define your dark palette
+4. Preview your components and pages in both light and dark mode using the light/dark mode toggle in the toolbar
 
-## How it works
+<Tip>
+  Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
+</Tip>
 
-1. Configure Tailwind to use CSS variables instead of hardcoded colors
-2. Define light mode colors from your Subframe theme as CSS variables
-3. Define dark mode color overrides under an `html.dark` selector
-4. Toggle between modes by adding/removing the `dark` class on the HTML element
+To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
 
-This keeps your Subframe workflow unchanged while enabling dark mode in your application.
+## How the generated code works
 
-## Step 1: Configure Tailwind for CSS variables
+When dark mode is enabled, Subframe generates theme tokens as CSS variables so light and dark values can switch at runtime.
 
 <Tabs>
 <Tab title="Tailwind v3">
 
-Modify your `tailwind.config.js` to use CSS variables.
+The CLI syncs two files:
 
-<Note>Add `// @subframe/sync-disable` at the top to prevent Subframe from overwriting your changes.</Note>
+- **`tailwind.config.js`** — references CSS variables instead of hardcoded values, with `darkMode: 'selector'` enabled
+- **`theme.css`** — defines `:root` variables for light mode and `.dark` overrides for dark mode
 
-```js tailwind.config.js {1, 3}
-// @subframe/sync-disable
+```js tailwind.config.js
 module.exports = {
-  darkMode: "selector", // Enable class-based dark mode
+  darkMode: 'selector',
   theme: {
     extend: {
       colors: {
-        brand: {
-          50: "var(--brand-50)",
-          100: "var(--brand-100)",
-          // ... rest of your brand colors as CSS variables
-        },
-        neutral: {
-          0: "var(--neutral-0)",
-          50: "var(--neutral-50)",
-          // ... rest of your neutral colors
-        },
-        // Continue for error, warning, success, etc.
-        "brand-primary": "var(--brand-primary)",
-        "default-font": "var(--default-font)",
-        "subtext-color": "var(--subtext-color)",
-        "neutral-border": "var(--neutral-border)",
-        white: "var(--white)",
-        "default-background": "var(--default-background)",
+        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
+        // ... all color tokens as CSS variable references
       },
     },
   },
 }
 ```
 
-<Note>
-  Find your theme configuration in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV3).
-</Note>
+```css theme.css
+:root {
+  --color-brand-primary: 26 26 26;
+  --color-default-background: 252 252 252;
+  /* ... light mode values */
+}
+
+.dark {
+  --color-brand-primary: 212 212 212;
+  --color-default-background: 10 10 10;
+  /* ... dark mode overrides */
+}
+```
+
+Import `theme.css` in your global stylesheet or entry point:
+
+```css globals.css
+@import "./subframe/theme.css";
+```
 
 </Tab>
 <Tab title="Tailwind v4">
 
-Modify your `theme.css` to use CSS variables and add the dark mode custom variant:
+The generated `theme.css` includes a `@custom-variant` for dark mode and a `.dark` block with overrides:
 
-```css theme.css {1-3, 295}
+```css theme.css
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
-  /* Replace hardcoded colors with CSS variables */
-  --color-brand-50: var(--brand-50);
-  --color-brand-100: var(--brand-100);
-  /* ... continue for all colors */
-
-  /* Keep fonts, shadows, borders, spacing as-is */
+  --color-brand-primary: rgb(26 26 26);
+  --color-default-background: rgb(252 252 252);
+  /* ... light mode values */
 }
 
-/* Enable dark mode */
-@custom-variant dark (&:where(.dark, .dark *));
+.dark {
+  --color-brand-primary: rgb(212 212 212);
+  --color-default-background: rgb(10 10 10);
+  /* ... dark mode overrides */
+}
 ```
-
-<Note>
-  Find your theme.css in the [Theme
-  tab](https://app.subframe.com/library?component=theme&showThemeModalCSSType=tailwindV4).
-</Note>
 
 </Tab>
 </Tabs>
 
-## Step 2: Create CSS variables file
+## Sync to code
 
-Create a `variables.css` file that defines CSS variables for both light and dark modes:
+Run the CLI to sync your theme (including dark mode) to your codebase:
 
-```css variables.css
-/* Light mode */
+<CliSyncAllCommand />
 
-html {
-  --brand-50: rgb(250, 250, 250);
-  --brand-100: rgb(245, 245, 245);
-  /* ... rest of brand colors */
+## Enable dark mode in your app
 
-  --neutral-0: rgb(255, 255, 255);
-  --neutral-50: rgb(247, 247, 247);
-  /* ... rest of neutral colors */
-
-  /* Semantic colors */
-  --brand-primary: rgb(26, 26, 26);
-  --default-font: rgb(41, 41, 41);
-  --subtext-color: rgb(117, 117, 117);
-  --neutral-border: rgb(240, 240, 240);
-  --white: rgb(255, 255, 255);
-  --default-background: rgb(252, 252, 252);
-}
-
-/* Dark mode */
-
-html.dark {
-  --brand-50: rgb(23, 23, 23);
-  --brand-100: rgb(38, 38, 38);
-  /* ... inverted brand colors (light becomes dark) */
-
-  --neutral-0: rgb(10, 10, 10);
-  --neutral-50: rgb(23, 23, 23);
-  /* ... inverted neutral colors */
-
-  /* Dark semantic colors */
-  --brand-primary: rgb(212, 212, 212);
-  --default-font: rgb(250, 250, 250);
-  --subtext-color: rgb(163, 163, 163);
-  --neutral-border: rgb(64, 64, 64);
-  --white: rgb(10, 10, 10);
-  --default-background: rgb(10, 10, 10);
-}
-```
-
-<Tip>
-  Dark mode colors typically invert the scale: light mode's `--brand-50` (lightest) becomes dark mode's `--brand-900`
-  (darkest), and vice versa.
-</Tip>
-
-## Step 3: Import variables globally
-
-Import your `variables.css` in your global CSS file (typically `index.css`, `globals.css`, or `App.css` depending on framework):
-
-```css globals.css
-@import "./variables.css";
-@import "tailwindcss";
-```
-
-Or import directly in your entry point:
-
-```tsx main.tsx
-import "./variables.css"
-```
-
-## Step 4: Toggle dark mode
-
-Add or remove the `dark` class on the `<html>` element to switch themes.
+To activate dark mode, set the `dark` class on the `<html>` element. Here are a few ways to accomplish that:
 
 ### Next.js with next-themes
 

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -5,19 +5,19 @@ description: Add dark mode to your project using Subframe's built-in theme suppo
 
 import CliSyncAllCommand from "/snippets/cli-sync-all-command.mdx"
 
-Subframe has built-in dark mode support. Enable it in your theme to define light and dark color values side by side, then export or sync to get a fully configured Tailwind setup.
+Subframe has built-in dark mode support. Enable it in your theme to define light and dark values side by side, then sync to get a fully configured Tailwind setup.
 
 ## Enable dark mode
 
 1. Open **Theme** in the top navigation
 2. In the Colors section, click **Add dark mode** (or toggle dark mode on from the theme presets)
-3. Each color token now shows light and dark values — edit the dark values to define your dark palette
+3. Each token now shows light and dark values — edit the dark values to define your dark palette
 
 <Tip>
   Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
 </Tip>
 
-To remove dark mode, click **⋯** in the Colors section and select **Remove dark mode**. This deletes all dark color overrides. You can undo this using version history.
+To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
 
 ## How the generated code works
 
@@ -95,9 +95,9 @@ Run the CLI to sync your theme (including dark mode) to your codebase:
 
 <CliSyncAllCommand />
 
-## Toggle dark mode in your app
+## Enable dark mode in your app
 
-Add or remove the `dark` class on the `<html>` element to switch between light and dark mode.
+To activate dark mode, set the `dark` class on the `<html>` element. Here are a few ways to accomplish that:
 
 ### Next.js with next-themes
 
@@ -139,7 +139,7 @@ export function ThemeProvider({ children }) {
 
   const toggleTheme = () => setTheme(theme === "light" ? "dark" : "light")
 
-  return <ThemeContext.Provider value=undefined>{children}</ThemeContext.Provider>
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
 }
 
 export const useTheme = () => useContext(ThemeContext)

--- a/packages/docs/learn/theme/exporting-theme.mdx
+++ b/packages/docs/learn/theme/exporting-theme.mdx
@@ -22,6 +22,11 @@ Click **Copy to clipboard** to copy either format.
 
 The generated config includes colors, font sizes, font families, box shadows, border radius, container settings, and responsive breakpoints.
 
+When [dark mode](/guides/dark-mode) is enabled, the export includes additional dark mode overrides:
+
+- **Tailwind v3** — An additional `theme.css` file with `:root` and `.dark` CSS variable blocks, and `darkMode: 'selector'` in the config
+- **Tailwind v4** — A `.dark` block and `@custom-variant dark` declaration in the `theme.css` file
+
 ## Sync to code
 
 Run the CLI to sync your theme and components to your codebase:

--- a/plugins/claude/subframe/.claude-plugin/plugin.json
+++ b/plugins/claude/subframe/.claude-plugin/plugin.json
@@ -1,14 +1,22 @@
 {
   "name": "subframe",
   "description": "Design and build UIs with Subframe. Create pixel-perfect React + Tailwind pages using your design system, explore design variations, and implement with business logic.",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": {
     "name": "Subframe"
   },
   "homepage": "https://subframe.com",
   "repository": "https://github.com/SubframeApp/subframe",
   "license": "MIT",
-  "keywords": ["design", "ui", "react", "tailwind", "components", "design-system", "frontend"],
+  "keywords": [
+    "design",
+    "ui",
+    "react",
+    "tailwind",
+    "components",
+    "design-system",
+    "frontend"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/claude/subframe/skills/develop/SKILL.md
+++ b/plugins/claude/subframe/skills/develop/SKILL.md
@@ -134,6 +134,30 @@ const handleSubmit = async (e: FormEvent) => {
 <Card actionSlot={<IconButton onClick={handleDelete} />} />
 ```
 
+## Dark Mode
+
+If the Subframe project has dark mode enabled, the synced theme uses CSS variables with `.dark` class overrides. To activate dark mode in the app, set the `dark` class on the `<html>` element.
+
+For Next.js projects, use `next-themes`:
+
+```bash
+npm install next-themes
+```
+
+```tsx app/layout.tsx
+import { ThemeProvider } from "next-themes"
+
+<ThemeProvider attribute="class" defaultTheme="system">
+  {children}
+</ThemeProvider>
+```
+
+For other React projects, toggle the class manually:
+
+```tsx
+document.documentElement.classList.toggle("dark")
+```
+
 ## Updating Existing Pages
 
 When a design changes:

--- a/plugins/claude/subframe/skills/develop/SKILL.md
+++ b/plugins/claude/subframe/skills/develop/SKILL.md
@@ -136,27 +136,7 @@ const handleSubmit = async (e: FormEvent) => {
 
 ## Dark Mode
 
-If the Subframe project has dark mode enabled, the synced theme uses CSS variables with `.dark` class overrides. To activate dark mode in the app, set the `dark` class on the `<html>` element.
-
-For Next.js projects, use `next-themes`:
-
-```bash
-npm install next-themes
-```
-
-```tsx app/layout.tsx
-import { ThemeProvider } from "next-themes"
-
-<ThemeProvider attribute="class" defaultTheme="system">
-  {children}
-</ThemeProvider>
-```
-
-For other React projects, toggle the class manually:
-
-```tsx
-document.documentElement.classList.toggle("dark")
-```
+If the Subframe project has dark mode enabled, the synced theme uses CSS variables with `.dark` class overrides. To activate dark mode in the app, set the `dark` class on the `<html>` element — using `next-themes`, a React theme provider context, or any other method.
 
 ## Updating Existing Pages
 

--- a/plugins/claude/subframe/skills/setup/SKILL.md
+++ b/plugins/claude/subframe/skills/setup/SKILL.md
@@ -199,6 +199,14 @@ After init, verify everything was set up correctly. If the CLI missed something 
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   ```
 
+  If the Subframe project has dark mode enabled, the CLI also syncs a `theme.css` file with CSS variables for light and dark modes. The global CSS file must import it:
+
+  ```css
+  @import "./ui/theme.css";
+  ```
+
+  Without this import, dark mode tokens won't be available at runtime.
+
 - **Tailwind v4** — Global CSS file should import the theme:
   ```css
   @import "tailwindcss";

--- a/plugins/claude/subframe/skills/setup/SKILL.md
+++ b/plugins/claude/subframe/skills/setup/SKILL.md
@@ -199,6 +199,12 @@ After init, verify everything was set up correctly. If the CLI missed something 
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   ```
 
+  If the Subframe project has dark mode enabled, the CLI also syncs a `theme.css` file with CSS variables for light and dark modes. The global CSS file must import it:
+
+  ```css
+  @import "./ui/theme.css";
+  ```
+
 - **Tailwind v4** — Global CSS file should import the theme:
   ```css
   @import "tailwindcss";

--- a/plugins/claude/subframe/skills/setup/SKILL.md
+++ b/plugins/claude/subframe/skills/setup/SKILL.md
@@ -199,14 +199,6 @@ After init, verify everything was set up correctly. If the CLI missed something 
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   ```
 
-  If the Subframe project has dark mode enabled, the CLI also syncs a `theme.css` file with CSS variables for light and dark modes. The global CSS file must import it:
-
-  ```css
-  @import "./ui/theme.css";
-  ```
-
-  Without this import, dark mode tokens won't be available at runtime.
-
 - **Tailwind v4** — Global CSS file should import the theme:
   ```css
   @import "tailwindcss";


### PR DESCRIPTION
## Summary

Subframe now has built-in dark mode support in the theme editor ([SUB-3465](https://github.com/SubframeApp/design-tool-app/pull/2859)). This PR updates the docs to reflect the new native workflow.

### Changes

**`guides/dark-mode.mdx`** — Rewritten to lead with native dark mode:
- Enable dark mode in the Theme editor → edit dark values per token
- CLI/export now generates `theme.css` with `:root` and `.dark` variable blocks (v3) or `@custom-variant dark` + `.dark` block (v4)
- Tailwind config references CSS variables when dark mode is on
- Removed the old manual CSS variables workaround as the primary approach
- Kept the toggle implementation section (next-themes, React context)

**`learn/theme/exporting-theme.mdx`** — Added a section explaining the additional dark mode output:
- Tailwind v3: additional `theme.css` file + `darkMode: 'selector'`
- Tailwind v4: `.dark` block + `@custom-variant`

### Source commit
- [SubframeApp/design-tool-app#2859](https://github.com/SubframeApp/design-tool-app/pull/2859) — Multiple Theme Data Model Change + Dark Mode

### Notes
- The exact UI for enabling dark mode in the editor (button label, location) may need verification against the shipped UI — I inferred from the code that it's in the Colors section header
- Images will need to be added manually once the feature is live