### PR TITLE
Update dark mode guide for new export format

### DIFF
--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -38,8 +38,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        "brand-primary": "rgb(var(--color-brand-primary) / <alpha-value>)",
-        // ... all color tokens as CSS variable references
+        "brand-primary": "var(--color-brand-primary)",
+        // ... all your color tokens
       },
     },
   },


### PR DESCRIPTION
Updates the dark mode guide to reflect the export changes from SubframeApp/design-tool-app#2918:

- Tailwind v3 color token references now use `var(--color-brand-primary)` directly instead of `rgb(var(...) / <alpha-value>)`
- `theme.css` values use full `rgb()` syntax (e.g., `rgb(26 26 26)`) instead of raw channel numbers
- Improved intro copy explaining that alpha baked into tokens is preserved in both modes
- Bullet descriptions updated for clarity