### PR TITLE
Docs audit: multi-theme sidebar, edit_theme, rate limiting, dark mode steps

### DIFF
--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -10,9 +10,10 @@ Subframe has built-in dark mode support. Enable it in your theme to define light
 ## Enable dark mode
 
 1. Open **Theme** in the top navigation
-2. In the Colors section, click **Add dark mode**
-3. Each token now shows light and dark values — edit the dark values to define your dark palette
-4. Preview your components and pages in both light and dark mode using the light/dark mode toggle in the toolbar
+2. In the left sidebar, select your theme under **Themes**
+3. In the Colors section, click **Add dark mode**
+4. Each token now shows light and dark values — edit the dark values to define your dark palette
+5. Preview in light or dark mode using the toggle in the toolbar
 
 <Tip>
   Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.

--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -31,7 +31,7 @@ Once configured, your AI assistant can access Subframe automatically when you pr
 | `get_component_info` | Gets the code and metadata for a component   | `id`, `name`, or `url`<br/>`projectId`            | `id`, `name`, `files`                        |
 | `get_page_info`      | Gets the code for a page                     | `id`, `name`, or `url`<br/>`projectId`            | `id`, `name`, `files`                        |
 | `get_theme`          | Generates the Tailwind theme for the project | `projectId`<br/>`cssType` (optional)              | `theme` config                               |
-| `edit_theme`         | Updates the Tailwind theme for the project   | `id`, `name`, or `url`<br/>`projectId`            | `editUrl`                                    |
+| `edit_theme`         | Edits the visual theme (colors, fonts, corners, shadows) of a project. Best for targeted tweaks or high-level style changes. If a page is specified, returns a preview URL to review and apply; otherwise applies immediately. | `description`<br/>`id`, `name`, or `url` (optional)<br/>`projectId` (optional) | `editUrl` |
 | `design_page`        | Designs UI pages in Subframe. Use to build new UI, iterate on existing UI, explore options, or get a visual starting point to refine. | `description`, `variations` (1, 2, or 4 objects with `name` and `description`), `flowName`<br/>`projectId`, `codeContext` (optional), `additionalPages` (optional) | `pageId`, `reviewUrl` |
 | `edit_page`          | Edits an existing Subframe page. Use for targeted changes to an existing page. Describe the changes you want, optionally including code snippets for precision. The edit is applied immediately. | `id`, `name`, or `url`<br/>`description`<br/>`projectId` | `pageUrl` |
 | `get_variations`     | Gets the status and generated code for variations from a `design_page` call. Use to retrieve variation code for iterating on designs. | `pageId` | `status`, `currentPageCode` (string or null), `variations` (array of `name`, `state`, `code`) |
@@ -123,6 +123,13 @@ Get my Subframe theme configuration
 ## Troubleshooting
 
 <AccordionGroup>
+<Accordion title="Rate limit error on design_page">
+
+The `design_page` tool is rate-limited per user. If you hit the limit, wait a few minutes before calling `design_page` again.
+
+For targeted changes to an existing design, use `edit_page` instead — it is not subject to the same limit.
+
+</Accordion>
 <Accordion title="Authentication failed">
 
 Most clients authenticate via OAuth. If you're seeing authentication errors:

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -9,9 +9,9 @@ Your theme defines design tokens for your project. Design tokens are reusable va
 
 Click **Theme** in the top navigation, or press <kbd>Cmd</kbd> + <kbd>K</kbd> and search "Theme".
 
-The theme page has a left sidebar for navigating between sections: Colors, Typography, Borders, Corners, and Shadows. Click any section to scroll to it.
+The theme page has a left sidebar with **Ask AI**, **Import**, and **Export** actions at the top, followed by a **Themes** section listing your project's themes. Click a theme to select it and expand its sections: Colors, Typography, Borders, Corners, and Shadows. Click any section to scroll to it.
 
-The Colors section header contains the main actions: **Ask AI**, **Import tokens**, **Export**, and a **⋯** menu with **Reset theme** and **Show version history**.
+The **⋯** menu next to the **Themes** subheader contains **Reset theme** and **Version history**.
 
 All changes save automatically and apply immediately across your project.
 


### PR DESCRIPTION
Docs audit fixes from @alex's 2026-05-06 review:

### `customizing-theme.mdx`
- Updated "Navigating the theme page" for multi-theme sidebar structure (Themes section, nested sections per theme, ⋯ menu moved)

### `mcp-server.mdx`
- Updated `edit_theme` table row: proper description, `description` param listed as required, conditional behavior noted
- Added rate limit troubleshooting accordion for `design_page`

### `dark-mode.mdx`
- Added step to select theme under Themes before accessing Colors section

**Holding:** inspector.mdx theme switcher section (behind `supportsMultiTheme` feature flag)

Ref: design-tool-app#2909, #2882, #2915, #2918