### PR TITLE
docs: align theme + dark mode docs with theme toolbar refactor

### DIFF
--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -10,15 +10,15 @@ Subframe has built-in dark mode support. Enable it in your theme to define light
 ## Enable dark mode
 
 1. Open **Theme** in the top navigation
-2. In the Colors section, click **Add dark mode**
+2. In the theme toolbar above the Colors section, click **Add dark mode**
 3. Each token now shows light and dark values — edit the dark values to define your dark palette
-4. Preview your components and pages in both light and dark mode using the light/dark mode toggle in the toolbar
+4. Preview your components and pages in both light and dark mode using the sun/moon toggle in the editor toolbar
 
 <Tip>
   Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
 </Tip>
 
-To remove dark mode, click **Remove dark mode** in the Colors section. This deletes all dark overrides. You can undo this using version history.
+To remove dark mode, click **Remove dark mode** in the theme toolbar. This deletes all dark overrides. You can undo this using version history.
 
 ## How the generated code works
 
@@ -48,14 +48,14 @@ module.exports = {
 
 ```css theme.css
 :root {
-  --color-brand-primary: 26 26 26;
-  --color-default-background: 252 252 252;
+  --color-brand-primary: rgb(26 26 26);
+  --color-default-background: rgb(252 252 252);
   /* ... light mode values */
 }
 
 .dark {
-  --color-brand-primary: 212 212 212;
-  --color-default-background: 10 10 10;
+  --color-brand-primary: rgb(212 212 212);
+  --color-default-background: rgb(10 10 10);
   /* ... dark mode overrides */
 }
 ```

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -9,9 +9,9 @@ Your theme defines design tokens for your project. Design tokens are reusable va
 
 Click **Theme** in the top navigation, or press <kbd>Cmd</kbd> + <kbd>K</kbd> and search "Theme".
 
-The theme page has a left sidebar for navigating between sections: Colors, Typography, Borders, Corners, and Shadows. Click any section to scroll to it.
+The left sidebar contains the main theme actions — **Ask AI**, **Import**, **Export** — and lists each section (Colors, Typography, Borders, Corners, Shadows) with token counts. Click any section to scroll to it. The **⋯** menu next to **Themes** holds **Version history** and **Reset theme**.
 
-The Colors section header contains the main actions: **Ask AI**, **Import tokens**, **Export**, and a **⋯** menu with **Reset theme** and **Show version history**.
+A toolbar above the Colors section shows the theme name and an **Add dark mode** / **Add light mode** toggle (or **Remove dark mode** when enabled). See [Dark mode](/guides/dark-mode) for details.
 
 All changes save automatically and apply immediately across your project.
 
@@ -99,6 +99,8 @@ Click any text token to edit:
 ### Changing font families
 
 Click the font name card at the top to select a different font family. This updates all tokens using that font. Choose from a curated list of Google Fonts or custom uploaded fonts.
+
+When dark mode is enabled, the font family card shows separate Light and Dark selectors so you can pair different fonts per mode.
 
 ### Adding custom fonts
 


### PR DESCRIPTION
## Summary

Aligns the theme and dark mode docs with two recent product changes in `design-tool-app`:

- **#2909 (Multi-theme refactor)** — Theme actions (Ask AI / Import / Export / Version history / Reset theme) moved from the **Colors** section header into a new **left sidebar** with a **Themes** subheader. A new toolbar above the Colors section holds the theme name and the **Add dark mode** / **Add light mode** / **Remove dark mode** button (formerly inside the Colors section).
- **#2918 (Font family card for dark mode + opacity for tailwind config)** — The font family card now renders separate Light and Dark selectors when dark mode is enabled. Generated v3 `theme.css` now emits `rgb(R G B)` wrapped values instead of bare RGB channels, because v3 `tailwind.config.js` no longer wraps them itself (already partially fixed in #142, this completes the `theme.css` half).

## Changes

- `guides/dark-mode.mdx`
  - "Add dark mode" instruction now points at the theme toolbar above the Colors section.
  - Preview toggle described as the **sun/moon** toggle in the editor toolbar (icon updated in #2918).
  - v3 `theme.css` example wraps values in `rgb(...)` so it matches the current code-gen output.
- `learn/theme/customizing-theme.mdx`
  - Rewrote "Navigating the theme page" so Ask AI / Import / Export / Version history / Reset theme all live in the sidebar (with the **⋯** next to **Themes**).
  - Documented the new theme toolbar with the dark/light mode toggle.
  - Added a note that the font family card splits into Light and Dark selectors when dark mode is enabled.

## Test plan

- [ ] Confirm sidebar copy ("Ask AI", "Import", "Export", "Themes", "Version history", "Reset theme") matches what ships when the multi-theme flag is off (the sidebar itself renders for everyone — only the **New theme** entry and theme **⋯** menu are flagged).
- [ ] Verify the v3 `theme.css` snippet matches the latest CLI output (`rgb(...)` wrapping).
- [ ] Spot-check the font family Light/Dark card description against the live UI.

## Open follow-ups (not in this PR)

- Multi-theme is currently feature-flagged (`supportsMultiTheme`). When it ships GA, the Theme docs should be updated to cover **New theme**, the per-theme **⋯** menu (Duplicate / Delete), and the Inspector theme switcher (`InspectorTheme`).
- Page inspector now surfaces a **Prototype** / **New prototype** row per active flow (#2878). `learn/prototype-mode/overview.mdx` could mention this as a second entry point.

https://claude.ai/code/session_01LSvc4U9Un2dMYDWqyJj3UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSvc4U9Un2dMYDWqyJj3UZ)_