### PR TITLE
docs: add troubleshooting for MCP write scope re-authorization

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -134,6 +134,15 @@ Most clients authenticate via OAuth. If you're seeing authentication errors:
 If your client doesn't support OAuth (e.g. Antigravity), authenticate using a Subframe token instead. Create a token at [**Settings > Access Tokens**](https://app.subframe.com/settings/tokens) and pass it as a header in your MCP configuration. See the [Other clients](#other-clients) installation tab for details.
 
 </Accordion>
+<Accordion title="edit_theme, design_page, or edit_page not working">
+
+These tools require write access to your project. If you connected the MCP server before these tools were available, you may need to re-authorize to grant the updated permissions:
+
+1. Disconnect the Subframe MCP server in your client
+2. Reconnect and complete the OAuth flow again
+3. On the consent screen, confirm that the permissions include **Read and edit your project theme**
+
+</Accordion>
 <Accordion title="AI not calling the server">
 
 Make sure your AI tool:


### PR DESCRIPTION
## What changed

The MCP server scope changed from `read:project` to `write:project` ([SubframeApp/design-tool-app#2931](https://github.com/SubframeApp/design-tool-app/commit/fe22b4621c)). This enables the `edit_theme`, `design_page`, and `edit_page` tools to work properly with write permissions.

Additionally, CLI token fallback was removed from MCP authentication ([SubframeApp/design-tool-app#2930](https://github.com/SubframeApp/design-tool-app/commit/3ce0c6194b)) — OAuth is now the only supported auth method (plus Access Tokens for clients that don't support OAuth, which still work via the existing documented flow).

## Docs change

Adds a new troubleshooting accordion to `guides/mcp-server.mdx` explaining that users who connected the MCP server before the scope change may need to re-authorize to use write tools (`edit_theme`, `design_page`, `edit_page`).

Preview: [MCP server troubleshooting](https://subframe-5glni0j.mintlify.app/guides/mcp-server#troubleshooting)