### PR TITLE
docs(mcp): refresh MCP server docs after auth + tool changes

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -31,7 +31,8 @@ Once configured, your AI assistant can access Subframe automatically when you pr
 | `get_component_info` | Gets the code and metadata for a component   | `id`, `name`, or `url`<br/>`projectId`            | `id`, `name`, `files`                        |
 | `get_page_info`      | Gets the code for a page                     | `id`, `name`, or `url`<br/>`projectId`            | `id`, `name`, `files`                        |
 | `get_theme`          | Generates the Tailwind theme for the project | `projectId`<br/>`cssType` (optional)              | `theme` config                               |
-| `edit_theme`         | Updates the Tailwind theme for the project   | `id`, `name`, or `url`<br/>`projectId`            | `editUrl`                                    |
+| `edit_theme`         | Edits the visual theme of a project (colors, fonts, corners, shadows) from a natural-language prompt. Best for targeted tweaks or high-level shifts. Optionally pass a page to preview the change before applying. | `description`<br/>`id`, `name`, or `url` (optional, page to preview)<br/>`projectId` | `editUrl`                                    |
+| `get_flow_info`      | Gets information about a flow, including the ordered list of pages it contains. | `id`, `name`, or `url`<br/>`projectId`            | `id`, `name`, `pages` (array of `id`, `name`) |
 | `design_page`        | Designs UI pages in Subframe. Use to build new UI, iterate on existing UI, explore options, or get a visual starting point to refine. | `description`, `variations` (1, 2, or 4 objects with `name` and `description`), `flowName`<br/>`projectId`, `codeContext` (optional), `additionalPages` (optional) | `pageId`, `reviewUrl` |
 | `edit_page`          | Edits an existing Subframe page. Use for targeted changes to an existing page. Describe the changes you want, optionally including code snippets for precision. The edit is applied immediately. | `id`, `name`, or `url`<br/>`description`<br/>`projectId` | `pageUrl` |
 | `get_variations`     | Gets the status and generated code for variations from a `design_page` call. Use to retrieve variation code for iterating on designs. | `pageId` | `status`, `currentPageCode` (string or null), `variations` (array of `name`, `state`, `code`) |
@@ -125,13 +126,12 @@ Get my Subframe theme configuration
 <AccordionGroup>
 <Accordion title="Authentication failed">
 
-Most clients authenticate via OAuth. If you're seeing authentication errors:
+The Subframe MCP server uses OAuth. If you're seeing authentication errors:
 
 - Try re-authenticating by reconnecting to the MCP server in your client
 - Check that you have the correct permissions for the project you're trying to access
 - Make sure your browser session is active when authenticating
-
-If your client doesn't support OAuth (e.g. Antigravity), authenticate using a Subframe token instead. Create a token at [**Settings > Access Tokens**](https://app.subframe.com/settings/tokens) and pass it as a header in your MCP configuration. See the [Other clients](#other-clients) installation tab for details.
+- Confirm your client supports MCP OAuth — static `Authorization: Bearer` tokens (including Subframe access tokens from **Settings > Access Tokens**) are not accepted by the MCP server
 
 </Accordion>
 <Accordion title="AI not calling the server">

--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -131,7 +131,7 @@ The Subframe MCP server uses OAuth. If you're seeing authentication errors:
 - Try re-authenticating by reconnecting to the MCP server in your client
 - Check that you have the correct permissions for the project you're trying to access
 - Make sure your browser session is active when authenticating
-- Confirm your client supports MCP OAuth — static `Authorization: Bearer` tokens (including Subframe access tokens from **Settings > Access Tokens**) are not accepted by the MCP server
+- Confirm your client supports MCP OAuth — Subframe access tokens are not accepted by the MCP server
 
 </Accordion>
 <Accordion title="AI not calling the server">

--- a/packages/docs/snippets/mcp-skills-install.mdx
+++ b/packages/docs/snippets/mcp-skills-install.mdx
@@ -161,3 +161,4 @@
     </Steps>
   </Tab>
 </Tabs>
+

--- a/packages/docs/snippets/mcp-skills-install.mdx
+++ b/packages/docs/snippets/mcp-skills-install.mdx
@@ -136,10 +136,6 @@
         - **URL:** `https://mcp.subframe.com/mcp`
         - **Transport:** HTTP
         - **Authentication:** OAuth (your client will handle the authentication flow)
-
-        <Note>
-          The Subframe MCP server requires OAuth. Static `Authorization: Bearer` tokens (including Subframe access tokens from **Settings > Access Tokens**) are not accepted — your client must support the MCP OAuth flow.
-        </Note>
       </Step>
       <Step title="Configure the Subframe Docs MCP Server (optional)">
         Optionally add the Subframe Docs MCP server for documentation access:

--- a/packages/docs/snippets/mcp-skills-install.mdx
+++ b/packages/docs/snippets/mcp-skills-install.mdx
@@ -136,6 +136,10 @@
         - **URL:** `https://mcp.subframe.com/mcp`
         - **Transport:** HTTP
         - **Authentication:** OAuth (your client will handle the authentication flow)
+
+        <Note>
+          The Subframe MCP server requires OAuth. Static `Authorization: Bearer` tokens (including Subframe access tokens from **Settings > Access Tokens**) are not accepted — your client must support the MCP OAuth flow.
+        </Note>
       </Step>
       <Step title="Configure the Subframe Docs MCP Server (optional)">
         Optionally add the Subframe Docs MCP server for documentation access:
@@ -159,30 +163,5 @@
         Follow the [Working with AI agents](/learn/guides/working-with-ai-agents) guide to design and implement your first page.
       </Step>
     </Steps>
-
-    ### Client doesn't support OAuth?
-
-    Some clients (e.g. Antigravity) do not support OAuth for custom MCP servers. Instead, authenticate using a Subframe token passed as a header:
-
-    1. Create a token at [**Settings > Access Tokens**](https://app.subframe.com/settings/tokens)
-    2. Use the following MCP server configuration:
-
-    ```json
-    {
-      "mcpServers": {
-        "subframe": {
-          "url": "https://mcp.subframe.com/mcp",
-          "headers": {
-            "Authorization": "Bearer <YOUR_SUBFRAME_TOKEN>"
-          }
-        },
-        "subframe-docs": {
-          "url": "https://docs.subframe.com/mcp"
-        }
-      }
-    }
-    ```
-
-    You may need to restart your client or start a new conversation for it to pick up the configuration.
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Documentation drift caught while auditing recent `design-tool-app` changes against the Subframe docs.
### Changes

**`packages/docs/snippets/mcp-skills-install.mdx`**
- Removes the "Client doesn't support OAuth?" subsection in the **Other clients** tab. The `Authorization: Bearer <YOUR_SUBFRAME_TOKEN>` config it documented now returns 401.
- Adds a `<Note>` callout in the same tab making it explicit that static Bearer tokens are not accepted.

**`packages/docs/guides/mcp-server.mdx`**
- Rewrites the `edit_theme` row in **Available tools**: the description now reflects AI-driven theme edits, and `description` is listed as a required parameter (with `id`/`name`/`url` as the optional preview-page selector).
- Adds a new `get_flow_info` row — the tool exists in `apps/mcp/api/mcp.ts` but was missing from the table.
- Updates the **Authentication failed** troubleshooting accordion: removes the now-broken "create a Subframe token, pass it as a header" workaround and replaces it with a bullet clarifying that static Bearer tokens (including Settings > Access Tokens) are not accepted.
