### PR TITLE
docs(mcp): add rate limit troubleshooting note for design_page

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -165,4 +165,9 @@ If the MCP server is unreachable:
 - Reach out to the Subframe team for support
 
 </Accordion>
+<Accordion title="Rate limit exceeded">
+
+The `design_page` tool has a per-user rate limit to keep generation responsive for everyone. If your AI assistant returns a message like "You've hit the rate limit for this endpoint. Please wait a few minutes before trying again," wait a few minutes and retry the request.
+
+</Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

- Adds a "Rate limit exceeded" accordion to the MCP server troubleshooting section so users hitting the per-user `design_page` rate limit have guidance on what the message means and what to do.

## Test plan

- [ ] Verify the new accordion renders correctly in the Mintlify preview
- [ ] Confirm the wording matches the actual rate-limit error message users see

https://claude.ai/code/session_01JHqa5jwG8HKaVeUWoPG5p4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHqa5jwG8HKaVeUWoPG5p4)_