### PR TITLE
docs: token context menu and pages-panel prototype entry

### DIFF
--- a/packages/docs/learn/prototype-mode/overview.mdx
+++ b/packages/docs/learn/prototype-mode/overview.mdx
@@ -14,7 +14,7 @@ Prototypes let you build real web apps from your page designs, synced with your 
 1. Create a new [flow](/learn/flows/flows)
 2. Design your screens in design mode
 3. Add [annotations](/learn/prototype-mode/annotations) describing functionality
-4. Click **Prototype** in navbar
+4. Click **Prototype** in the navbar, or open the **Prototype** entry under the active flow in the pages panel
 5. Type your first message in chat, then click **Send**
 
 AI may take a few minutes to create a prototype and will preview it when finished.

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -70,6 +70,14 @@ To quickly add tokens from an existing design system, see [Importing tokens](/le
 
 Click any token to open color picker. Set a direct color value or reference another token as an alias.
 
+### Token actions
+
+Right-click any token to open its context menu:
+
+- **Duplicate** — Create a copy of the token with the same value
+- **Delete** — Remove the token (any component references are detached)
+- **Move to folder** — Move a color token into another folder (color tokens only)
+
 ## Typography
 
 Text tokens define typography styles with font family, size, weight, line height, and letter spacing.
@@ -89,7 +97,7 @@ New tokens duplicate the properties from the first token. Typography tokens auto
 
 ### Editing text tokens
 
-Click any text token to edit:
+Click any text token to edit. Right-click for **Duplicate** or **Delete**.
 
 - **Font size** — Pixel value
 - **Line height** — Pixel value
@@ -131,7 +139,7 @@ When generating code, border styles turn into explicit values for the border:
 
 ### Editing border tokens
 
-Click any border token to edit:
+Click any border token to edit. Right-click for **Duplicate** or **Delete**.
 
 - **Border style** — Solid or dashed
 - **Border size** — Pixel width
@@ -156,7 +164,7 @@ Corner tokens auto-sort based on value.
 
 ### Editing corner tokens
 
-Click any corner token to edit radius value in pixels.
+Click any corner token to edit radius value in pixels. Right-click for **Duplicate** or **Delete**.
 
 ## Shadows
 
@@ -177,7 +185,7 @@ Shadow tokens auto-sort based on perceived shadow effect.
 
 ### Editing shadow tokens
 
-Click any shadow token to edit individual shadow layers. Each layer has:
+Click any shadow token to edit individual shadow layers. Right-click for **Duplicate** or **Delete**. Each layer has:
 
 - **Inset** — Whether shadow appears inside element
 - **X/Y offset** — Horizontal and vertical offset in pixels


### PR DESCRIPTION
Documents two newly available UX surfaces:

- **Customizing theme** — Adds a "Token actions" subsection covering the right-click context menu (Duplicate, Delete, plus Move to folder for color tokens), and adds a one-line right-click reminder to each non-color "Editing X tokens" subsection now that those token types support the same context menu.
- **Prototype with AI** — Notes that the **Prototype** entry under the active flow in the pages panel is a second entry point for opening prototype mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmAUnK2hcjXr8sf8ABHAZG)_