### PR TITLE
docs: surface Pages sidebar prototype rows and broadened token context menu

### DIFF
--- a/packages/docs/learn/prototype-mode/overview.mdx
+++ b/packages/docs/learn/prototype-mode/overview.mdx
@@ -14,10 +14,12 @@ Prototypes let you build real web apps from your page designs, synced with your 
 1. Create a new [flow](/learn/flows/flows)
 2. Design your screens in design mode
 3. Add [annotations](/learn/prototype-mode/annotations) describing functionality
-4. Click **Prototype** in navbar
+4. Click **Prototype** in navbar, or click **New prototype** under the active flow in the Pages sidebar
 5. Type your first message in chat, then click **Send**
 
 AI may take a few minutes to create a prototype and will preview it when finished.
+
+<Tip>Once a prototype exists, the Pages sidebar shows a **Prototype** row (with a version number like `v3`) under the active flow. Click it to jump straight back into prototype mode.</Tip>
 
 ## Iterating on prototypes
 

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -64,6 +64,8 @@ To quickly add tokens from an existing design system, see [Importing tokens](/le
 
 **Reordering:** Drag folders or tokens to reorder. Use the **...** menu on a folder to move it up or down.
 
+**Token actions:** Right-click any token (color, typography, border, corner, or shadow) to duplicate or delete it. Color tokens also include a **Move to folder** submenu.
+
 <Note>Deleting a folder deletes all tokens inside it. Any component references to deleted tokens are detached.</Note>
 
 ### Editing color tokens


### PR DESCRIPTION
## Summary

- Note the alternate **Prototype** / **New prototype** entry points that now appear under the active flow in the Pages sidebar, in `learn/prototype-mode/overview.mdx`.
- Add a "Token actions" blurb in `learn/theme/customizing-theme.mdx` covering right-click duplicate/delete on every token type (color, typography, border, corner, shadow), and the color-only **Move to folder** submenu.

## Test plan

- [ ] Mintlify preview renders both pages with the new wording and `<Tip>` callout
- [ ] Right-clicking a typography/border/corner/shadow token in the editor matches the documented behavior
- [ ] The Pages sidebar shows a **Prototype** row (with version label) under the active flow when a prototype exists, and **New prototype** otherwise

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3xzjziFNsnavKFVybfm6N)_