### PR TITLE
docs: refresh theme + dark mode references for new theme header

### DIFF
--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -10,7 +10,7 @@ Subframe has built-in dark mode support. Enable it in your theme to define light
 ## Enable dark mode
 
 1. Open **Theme** in the top navigation
-2. In the theme toolbar above the Colors section, click **Add dark mode**
+2. At the top of the theme page, click **Add dark mode**
 3. Each token now shows light and dark values — edit the dark values to define your dark palette
 4. Preview your components and pages in both light and dark mode using the sun/moon toggle in the editor toolbar
 
@@ -18,7 +18,7 @@ Subframe has built-in dark mode support. Enable it in your theme to define light
   Dark mode colors typically invert the scale: light mode's lightest shade becomes dark mode's darkest, and vice versa.
 </Tip>
 
-To remove dark mode, click **Remove dark mode** in the theme toolbar. This deletes all dark overrides. You can undo this using version history.
+To remove dark mode, click **⋯** in the theme header and select **Remove dark mode**. This deletes all dark overrides. You can undo this using version history.
 
 ## How the generated code works
 

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -11,7 +11,7 @@ Click **Theme** in the top navigation, or press <kbd>Cmd</kbd> + <kbd>K</kbd> an
 
 The left sidebar contains the main theme actions — **Ask AI**, **Import**, **Export** — and lists each section (Colors, Typography, Borders, Corners, Shadows) with token counts. Click any section to scroll to it. The **⋯** menu next to **Themes** holds **Version history** and **Reset theme**.
 
-A toolbar above the Colors section shows the theme name and an **Add dark mode** / **Add light mode** toggle (or **Remove dark mode** when enabled). See [Dark mode](/guides/dark-mode) for details.
+A header above the Colors section shows the editable theme name, an **Add dark mode** / **Add light mode** button, and a **⋯** menu with **Duplicate theme**, **Delete theme**, and **Remove dark mode** / **Remove light mode** when applicable. See [Dark mode](/guides/dark-mode) for details.
 
 All changes save automatically and apply immediately across your project.
 


### PR DESCRIPTION
## Summary

The theme page no longer shows the dark-mode controls inside a toolbar. The theme name, **Add dark mode** / **Add light mode** button, and **Remove** / **Duplicate** / **Delete** actions now live in a header above the Colors section (Duplicate, Delete, and Remove sit inside the header's **⋯** menu).

- `learn/theme/customizing-theme.mdx`: rewrite the toolbar paragraph to describe the new header and its **⋯** menu.
- `guides/dark-mode.mdx`: update the enable step and the removal instruction so users look in the header (not a toolbar) and reach **Remove dark mode** via the **⋯** menu.

## Test plan

- [ ] Confirm the rendered text in the Mintlify preview reads naturally for both single-theme and multi-theme projects.
- [ ] Spot-check that no other doc pages still refer to a "theme toolbar".


---
_Generated by [Claude Code](https://claude.ai/code/session_01LErFQ4RCsJYML984iiwNqc)_