### PR TITLE
docs: add Shift+Space preview shortcut and Cmd+. panel toggle

### DIFF
--- a/packages/docs/learn/design-mode/preview.mdx
+++ b/packages/docs/learn/design-mode/preview.mdx
@@ -5,4 +5,4 @@ description: Preview your designs and test interactions.
 
 Preview mode shows how your design behaves outside the editor. Interactions like hover states work in preview.
 
-To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar.
+To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar, or press <kbd>Shift</kbd> + <kbd>Space</kbd>. From the flow editor, the same shortcut previews the flow starting from its first page.

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -41,7 +41,7 @@ The editor consists of three main areas: left panel, canvas (center), and Inspec
 
 ### Left panel
 
-Toggle left panel buttons with <kbd>Cmd</kbd> + <kbd>\\</kbd>. You have the following panels available to you:
+Step through the left panel states (visible, collapsed, hidden) with <kbd>Cmd</kbd> + <kbd>\\</kbd>, or press <kbd>Cmd</kbd> + <kbd>.</kbd> to show/hide all panels at once. You have the following panels available to you:
 
 **Pages** — Switch between pages and flows in your project. Navigate to different designs or subcomponents when editing components.
 

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -41,7 +41,7 @@ The editor consists of three main areas: left panel, canvas (center), and Inspec
 
 ### Left panel
 
-Step through the left panel states (visible, collapsed, hidden) with <kbd>Cmd</kbd> + <kbd>\\</kbd>, or press <kbd>Cmd</kbd> + <kbd>.</kbd> to show/hide all panels at once. You have the following panels available to you:
+You have the following panels available to you:
 
 **Pages** — Switch between pages and flows in your project. Navigate to different designs or subcomponents when editing components.
 
@@ -60,6 +60,10 @@ Unlike infinite canvas tools, Subframe uses flexbox for layout (not absolute pos
 This is the context-aware properties panel that changes based on editor mode and selected element.
 
 For example, in design mode, you'll see layout, sizing, colors, backgrounds, borders, shadows, padding, overflow, and component properties. In code mode, you'll see the Inspect tab, which shows the code for the selected element.
+
+### Show and hide panels
+
+Press <kbd>Cmd</kbd> + <kbd>\\</kbd> to cycle through panel layouts: both panels visible, left panel collapsed, then both panels hidden. Press <kbd>Cmd</kbd> + <kbd>.</kbd> to show or hide all panels at once.
 
 ## Responsive breakpoints
 


### PR DESCRIPTION
## Summary

- **Previewing designs** — surface the new <kbd>Shift</kbd> + <kbd>Space</kbd> shortcut for previewing the current page, component, or flow.
- **Editor overview / Left panel** — clarify that <kbd>Cmd</kbd> + <kbd>\\</kbd> steps through panel visibility states and document the new <kbd>Cmd</kbd> + <kbd>.</kbd> shortcut that shows/hides all panels at once.

Both shortcuts are listed in the in-app keyboard shortcuts modal but were not yet reflected in the docs.

## Test plan

- [ ] Mintlify preview renders the new shortcut text on `/learn/design-mode/preview`
- [ ] Mintlify preview renders the updated panel-toggle text on `/learn/editor/overview`

https://claude.ai/code/session_01Wom8opJyAcHuVaGYqSXbm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wom8opJyAcHuVaGYqSXbm5)_