### PR TITLE
docs: document double-tap Esc to exit nested editors

### DIFF
--- a/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
+++ b/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
@@ -17,3 +17,12 @@ You can also press <kbd>Cmd</kbd> + <kbd>K</kbd> to quickly navigate to another 
 <Frame>
   <img src="/images/design-mode/cmd-k.png" alt="Cmd + K keyboard shortcut showing the search input" />
 </Frame>
+
+## Exit a nested editor
+
+Press <kbd>Esc</kbd> twice to step back out of a nested editor:
+
+- From a subcomponent or snippet, return to the parent component
+- From a page that belongs to a flow, return to the flow editor
+
+The first <kbd>Esc</kbd> blurs any focused input or pulses the canvas as feedback; press it again to exit.

--- a/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
+++ b/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
@@ -25,4 +25,4 @@ Press <kbd>Esc</kbd> twice to navigate back up your editing history:
 - From a component or snippet that you opened from another design, return to that previous design
 - From a page inside a flow, return to the flow editor
 
-In the flow page editor, the canvas pulses on the first press as visual feedback.
+In the page editor, the canvas pulses on the first press as visual feedback.

--- a/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
+++ b/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
@@ -22,7 +22,7 @@ You can also press <kbd>Cmd</kbd> + <kbd>K</kbd> to quickly navigate to another 
 
 Press <kbd>Esc</kbd> twice to navigate back up your editing history:
 
-- From a component or snippet you opened from another component, return to that previous component editor
+- From a component or snippet that you opened from another design, return to that previous design
 - From a page inside a flow, return to the flow editor
 
-The first <kbd>Esc</kbd> arms a short window — press it again to exit. In the flow page editor, the canvas pulses on the first press as visual feedback.
+In the flow page editor, the canvas pulses on the first press as visual feedback.

--- a/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
+++ b/packages/docs/learn/design-mode/keyboard-shortcuts.mdx
@@ -18,11 +18,11 @@ You can also press <kbd>Cmd</kbd> + <kbd>K</kbd> to quickly navigate to another 
   <img src="/images/design-mode/cmd-k.png" alt="Cmd + K keyboard shortcut showing the search input" />
 </Frame>
 
-## Exit a nested editor
+## Step back to where you came from
 
-Press <kbd>Esc</kbd> twice to step back out of a nested editor:
+Press <kbd>Esc</kbd> twice to navigate back up your editing history:
 
-- From a subcomponent or snippet, return to the parent component
-- From a page that belongs to a flow, return to the flow editor
+- From a component or snippet you opened from another component, return to that previous component editor
+- From a page inside a flow, return to the flow editor
 
-The first <kbd>Esc</kbd> blurs any focused input or pulses the canvas as feedback; press it again to exit.
+The first <kbd>Esc</kbd> arms a short window — press it again to exit. In the flow page editor, the canvas pulses on the first press as visual feedback.


### PR DESCRIPTION
## Summary

Pressing Esc twice now steps back out of a subcomponent, snippet, or
flow page editor. The first press provides feedback (input blur or
canvas pulse), and the second exits. Add this to the keyboard
shortcuts page so the gesture is discoverable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YRhRFfpMBkwGVTKUDwixXa)_