### PR TITLE
docs: add page tile shortcut for copying MCP link

### DIFF
--- a/packages/docs/snippets/copy-mcp-link.mdx
+++ b/packages/docs/snippets/copy-mcp-link.mdx
@@ -1,7 +1,8 @@
-You can get the MCP link for any design by either:
+You can get the MCP link for any design by:
 
 - Copying the link from the browser address bar
 - Copying the link under **Code** > **Inspect** in Subframe
+- Hovering or selecting a page on the flow canvas and clicking the <Icon icon="link" size={16} /> button on the page tile
 
 <Frame>
   <img src="/images/developers/copy-mcp-link.png" alt="Copy MCP link from Subframe" />


### PR DESCRIPTION
## Summary

- Update the `copy-mcp-link` snippet to mention the third way to grab an MCP link: the link button that now appears on each page tile in the flow canvas when hovered or selected. The snippet is reused on the MCP server guide and the Working with AI agents guide, so both pick up the new bullet automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QsrPBGcebCvNF7s2azHkz6)_