### PR TITLE
Docs: document token usage finder and website URL references in Ask AI

### DIFF
--- a/packages/docs/learn/ask-ai/image-to-design.mdx
+++ b/packages/docs/learn/ask-ai/image-to-design.mdx
@@ -1,6 +1,6 @@
 ---
 title: Image to design
-description: Upload images to prompt AI when generating designs.
+description: Use images, Figma frames, and website URLs as references when generating designs.
 ---
 
 Upload screenshots or mockups and Ask AI to recreate designs using your components and theme.
@@ -20,3 +20,13 @@ Supported formats: PNG, JPG, JPEG, WebP
 1. In Figma, select a frame to copy as PNG (right-click or press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>)
 2. In Ask AI, paste the image into the prompt area
 3. Add a prompt and press <kbd>Enter</kbd>
+
+## Reference a website
+
+Paste a URL into your prompt and Ask AI fetches the live page — capturing a screenshot and its HTML — to use as a design reference.
+
+1. Paste a URL into the prompt area
+2. Describe what to build from it
+3. Press <kbd>Enter</kbd> to generate
+
+Ask AI links to the page it fetched in the conversation as it works. For security, it only fetches URLs you paste directly.

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -187,6 +187,14 @@ Click any shadow token to edit individual shadow layers. Each layer has:
 
 Add multiple layers for complex shadow effects.
 
+## Finding token usage
+
+To see everywhere a token is used before editing or deleting it, right-click any token and select **Find usage...**. A list shows every component that references the token, along with which property uses it — background, text color, border, and so on.
+
+Click a component to preview it, then click **Go to component** to open it in the editor. If nothing references the token, the list is empty.
+
+{/* TODO: Add image of the token Find usage view */}
+
 ## Theme presets
 
 <img src="/images/theme/theme-presets.png" alt="Edit theme dialog with theme preset controls and a preview" />


### PR DESCRIPTION
Adds a "Finding token usage" section to the theme docs and a "Reference a website" section to the image-to-design docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AucmKekt5nTveMqRktsSaN)_