### PR TITLE
Document theme token usage finder and URL references in Ask AI

### DIFF
--- a/packages/docs/learn/ask-ai/image-to-design.mdx
+++ b/packages/docs/learn/ask-ai/image-to-design.mdx
@@ -1,9 +1,9 @@
 ---
 title: Image to design
-description: Upload images to prompt AI when generating designs.
+description: Upload images or paste URLs to prompt AI when generating designs.
 ---
 
-Upload screenshots or mockups and Ask AI to recreate designs using your components and theme.
+Upload screenshots, mockups, or paste website URLs and Ask AI will recreate designs using your components and theme.
 
 ## Upload an image
 
@@ -14,6 +14,16 @@ Upload screenshots or mockups and Ask AI to recreate designs using your componen
 AI analyzes the image and creates 1-4 variations that match the structure using your Subframe components.
 
 Supported formats: PNG, JPG, JPEG, WebP
+
+## Reference a URL
+
+Paste a public URL into the prompt area to use a live page as a reference. Ask AI loads the page, captures a screenshot, and reads the structure so generations can match both the visuals and the layout.
+
+1. Paste the URL into the Ask AI prompt
+2. Add a prompt — for example, "redesign this landing page with our theme" or "recreate the pricing section using our components"
+3. Press <kbd>Enter</kbd> to generate
+
+<Note>Only URLs you paste are fetched. Authenticated or private pages cannot be loaded.</Note>
 
 ## Import from Figma
 

--- a/packages/docs/learn/ask-ai/prompt-to-design.mdx
+++ b/packages/docs/learn/ask-ai/prompt-to-design.mdx
@@ -76,6 +76,7 @@ Ask AI includes additional tools:
 
 - **[Referencing pages](/learn/ask-ai/referencing-pages)** — Remix other pages as prompts for your design
 - **[Upload image](/learn/ask-ai/image-to-design)** — Add reference images
+- **[Reference a URL](/learn/ask-ai/image-to-design#reference-a-url)** — Paste a public URL to use a live page as a reference
 - **[Import from Figma](/learn/ask-ai/image-to-design#import-from-figma)** — Import Figma designs using the image model
 - **[Personalize AI](/learn/ask-ai/personalizing-ai)** — Configure project-wide context
 

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -17,6 +17,12 @@ All changes save automatically and apply immediately across your project.
 
 See also: [Importing tokens](/learn/theme/importing-tokens), [Exporting theme](/learn/theme/exporting-theme), [Adding custom fonts](/learn/theme/adding-custom-fonts)
 
+## Finding token usage
+
+Right-click any color, typography, border, corner, or shadow token and select **Find usage...** to see every component that references it. Search the list, click a component to preview it, then click **Go to component** to jump into the component editor.
+
+Check usage before renaming or deleting a token so you know what your changes will affect.
+
 ## Edit theme with Ask AI
 
 <img src="/images/theme/theme-ask-ai.webp" alt="The theme page with Ask AI prompt open, showing 'update the theme to be brutalist with bold blue accents' with the theme sidebar and color tokens visible" />

--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -19,7 +19,7 @@ See also: [Importing tokens](/learn/theme/importing-tokens), [Exporting theme](/
 
 ## Finding token usage
 
-Right-click any color, typography, border, corner, or shadow token and select **Find usage...** to see every component that references it. Search the list, click a component to preview it, then click **Go to component** to jump into the component editor.
+Right-click any color, typography, border, corner, or shadow token and select **Find usage...** to see every design that references it. Search the list, click a design to preview it, then click **Go to component** to jump into the editor.
 
 Check usage before renaming or deleting a token so you know what your changes will affect.
 


### PR DESCRIPTION
## Summary

- Adds a **Finding token usage** section to `learn/theme/customizing-theme.mdx` covering the new right-click **Find usage...** action available on color, typography, border, corner, and shadow tokens.
- Documents pasting URLs into Ask AI in `learn/ask-ai/image-to-design.mdx` (loads a screenshot and structure of the page) and links to it from the Ask AI toolbar list in `learn/ask-ai/prompt-to-design.mdx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na36pzpyKMQP9tXHRJ9ntE)_