### PR TITLE
Document component delete behavior and update detach scope

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -50,7 +50,7 @@ The Subframe MCP server exposes tools across several categories. Most read tools
 | `get_component_info` | Generated code plus attached design document | `id`/`name`/`url`, `projectId` | `id`, `name`, `lastModifiedAt`, `files`, `designDocuments` |
 | `design_component` | Designs a new component as an asynchronous background job | `description`, `name`, `projectId` | `componentId`, `componentUrl`, `jobId` |
 | `edit_component` | Edit an existing component as an asynchronous background job. Propagates to every page using the component | `id`/`name`/`url`, `description`, `projectId` | `componentUrl`, `jobId` |
-| `delete_component` | Delete a component or custom page layout. Detachable components detach their instances; non-detachable ones delete instances (with customizations inside); page layouts clear assignments. Some built-in components can't be deleted (`force` does not override). Refuses by default if in use — pass `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
+| `delete_component` | Delete a component or custom page layout. Detachable components detach their instances; non-detachable ones delete instances; page layouts clear assignments. Some built-in components can't be deleted (`force` does not override). Refuses by default if in use — pass `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
 
 ### Snippets
 

--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -50,7 +50,7 @@ The Subframe MCP server exposes tools across several categories. Most read tools
 | `get_component_info` | Generated code plus attached design document | `id`/`name`/`url`, `projectId` | `id`, `name`, `lastModifiedAt`, `files`, `designDocuments` |
 | `design_component` | Designs a new component as an asynchronous background job | `description`, `name`, `projectId` | `componentId`, `componentUrl`, `jobId` |
 | `edit_component` | Edit an existing component as an asynchronous background job. Propagates to every page using the component | `id`/`name`/`url`, `description`, `projectId` | `componentUrl`, `jobId` |
-| `delete_component` | Delete a component or page layout. Detaches instances or clears layouts. Refuses by default if in use. Use `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
+| `delete_component` | Delete a component or custom page layout. Detachable components detach their instances; non-detachable ones delete instances (with customizations inside); page layouts clear assignments. Some built-in components can't be deleted (`force` does not override). Refuses by default if in use — pass `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
 
 ### Snippets
 

--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -172,9 +172,22 @@ You can detach a component so the rendered elements are no longer linked to the 
 2. Select **Detach component**
 
 <Note>
-  Not all components can be detached; interactive components built on Radix (like accordions, checkboxes, etc) cannot be
-  detached.
+  Components whose structure relies on tightly coupled primitives — dropdowns, selects, dialogs, drawers, charts,
+  tables, and calendars — can't be detached. The **Detach component** action is hidden for these.
 </Note>
+
+## Deleting components
+
+You can delete a component from the **Components** page or from the **...** menu in the component editor.
+
+When a deleted component is used in other designs, Subframe handles existing instances based on the component type. The delete dialog shows what will happen before you confirm:
+
+- **Instances will be detached** — Custom components and most interactive primitives (buttons, switches, checkboxes, sliders, sidebars, navbars). Each instance becomes an independent copy of the rendered elements.
+- **Instances will be deleted** — Components whose structure can't survive on their own (dropdowns, selects, dialogs, drawers, charts, tables, calendars). Customizations inside each instance are removed with it.
+- **Layout assignments will be cleared** — Page layouts. The pages using the layout stay, but lose their layout assignment.
+- **References will be removed** — Custom pages referenced from prototype actions or other pages.
+
+Most deletes can't be undone with <kbd>Cmd</kbd> + <kbd>Z</kbd>. To recover a deleted component, restore an earlier snapshot from [Version history](/learn/projects/version-history).
 
 ## Resetting components
 

--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -169,7 +169,7 @@ You can add a component instance by
 You can detach a component so the rendered elements are no longer linked to the component.
 
 1. Right-click or press <kbd>/</kbd> to open [quick actions](/learn/design-mode/quick-actions)
-2. Select **Detach component**
+2. Select **Detach instance**
 
 <Note>
   Components whose structure relies on tightly coupled primitives — dropdowns, selects, dialogs, drawers, charts,


### PR DESCRIPTION
## Summary

- Refresh the **Detaching component instances** note in `learn/components/overview.mdx` to reflect that more built-in components are now detachable; only structurally-coupled primitives (dropdowns, selects, dialogs, drawers, charts, tables, calendars) stay non-detachable.
- Add a new **Deleting components** section to the same page that mirrors the delete-confirmation dialog: instances detached, instances deleted, layout assignments cleared, or references removed — depending on component type.
- Update the `delete_component` row in `guides/mcp-server.mdx` so the MCP reference matches the same effect taxonomy and notes that some built-in components can't be deleted (`force` does not override).


---
_Generated by [Claude Code](https://claude.ai/code/session_019uJEAPtWunitQnubVhHFSH)_