### PR TITLE
Document inspector controls for prebuilt interactive components

### DIFF
--- a/packages/docs/learn/design-mode/inspector.mdx
+++ b/packages/docs/learn/design-mode/inspector.mdx
@@ -22,6 +22,16 @@ Overrides let you customize properties for specific contexts without changing th
 
 When a property has an override, a pink dot appears next to it. Click the pink dot to remove the override and revert to the default value.
 
+## Prebuilt interactive components
+
+When you select an instance of a prebuilt interactive component, the inspector exposes its underlying state so you can preview how the component looks in different conditions:
+
+- **Checkbox**, **Switch** — toggle the **Checked** value
+- **Radio Group**, **Toggle Group** — pick which item is selected via the **Value** dropdown
+- **Text Field**, **Text Area** — type a default **Value** for the input
+
+These controls set the rendered state of the instance in design mode and preview. Runtime state in your generated code is still controlled by your application — see [headless components](/concepts/code-generation#headless-components) for details.
+
 ## Keyboard shortcuts
 
 Most properties in the inspector have a keyboard shortcut. Hover over any edit action to see its shortcut.

--- a/packages/docs/learn/design-mode/inspector.mdx
+++ b/packages/docs/learn/design-mode/inspector.mdx
@@ -24,13 +24,12 @@ When a property has an override, a pink dot appears next to it. Click the pink d
 
 ## Prebuilt interactive components
 
-When you select an instance of a prebuilt interactive component, the inspector exposes its underlying state so you can preview how the component looks in different conditions:
+The inspector lets you set the default state for some prebuilt components, so you can preview how they look in different conditions:
 
-- **Checkbox**, **Switch** — toggle the **Checked** value
-- **Radio Group**, **Toggle Group** — pick which item is selected via the **Value** dropdown
-- **Text Field**, **Text Area** — type a default **Value** for the input
+- **Checkbox**, **Switch**, **Radio Group item**, **Toggle Group item** — toggle the **Checked** prop
+- **Text Field**, **Text Area** — type into the **Value** prop
 
-These controls set the rendered state of the instance in design mode and preview. Runtime state in your generated code is still controlled by your application — see [headless components](/concepts/code-generation#headless-components) for details.
+These controls only affect how the instance renders in design mode and preview. Runtime state in generated code is controlled by your application — see [headless components](/concepts/code-generation#headless-components).
 
 ## Keyboard shortcuts
 


### PR DESCRIPTION
Adds a section to the inspector doc documenting the configurable state controls now surfaced for prebuilt interactive components:

- Checkbox / Switch — Checked toggle
- Radio Group / Toggle Group — Value selector
- Text Field / Text Area — Value input

Clarifies that these controls drive design-mode and preview rendering, while runtime state in generated code remains controlled by the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_016L81SuheXthkua9zwgx7Jk)_