### PR TITLE
Update Share button references to left panel icon

### DIFF
--- a/packages/docs/learn/design-mode/share-designs.mdx
+++ b/packages/docs/learn/design-mode/share-designs.mdx
@@ -7,13 +7,13 @@ All team members have access to your designs by default. The easiest way to shar
 
 ## Invite teammates
 
-1. Click **Share** in the navbar
+1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
 2. Type your teammates email in the input field
 3. Press **Invite**. They will receive an email to view the designs, and an invite to join your team if they're not already a member.
 
 ## Share public view-only link
 
-1. Click **Share** in the navbar
+1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
 2. Click the toggle to enable public sharing
 3. Copy the link that appears
 

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -81,10 +81,12 @@ We recommend you design for desktop first, then add mobile overrides only where 
 
 ## Collaboration
 
-Multiple team members can edit simultaneously. See who's viewing or editing with avatars in the top navigation.
+Multiple team members can edit simultaneously. See who's viewing or editing with avatars at the top of the left panel.
 
 <Frame>
   <img src="/images/editor/editor-collaborators.png" alt="Editor collaboration showing the team members and avatars" />
 </Frame>
 
-Click **Share** in the top navigation to invite team members or create view-only links. Set roles (viewer/editor) and toggle public preview access.
+Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar, to invite team members or create view-only links. Set roles (viewer/editor) and toggle public preview access.
+
+{/* TODO: Update screenshot — the Share control is now a user-plus icon button next to your avatar at the top of the left panel */}

--- a/packages/docs/learn/prototype-mode/overview.mdx
+++ b/packages/docs/learn/prototype-mode/overview.mdx
@@ -73,7 +73,7 @@ This will download your prototype code as a Vite app in a zip file.
 
 ## Sharing prototypes
 
-1. Click **Share** in navbar
+1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
 2. Toggle on **Share link to latest prototype**
 3. Copy and paste the generated link
 


### PR DESCRIPTION
Updates the Share button references to reflect that it is now a user-plus icon at the top of the left panel, next to your avatar.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gY8rUD7hEB354oPH3RpDG)_