### PR TITLE
Make the CLI agent/CI friendly (non-interactive mode)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22308,7 +22308,7 @@
     },
     "packages/subframe-cli": {
       "name": "@subframe/cli",
-      "version": "1.208.0",
+      "version": "1.209.0",
       "license": "ISC",
       "dependencies": {
         "@antfu/ni": "0.21.8",

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -52,6 +52,7 @@
               "guides/component-docs",
               "guides/accessibility",
               "guides/testing",
+              "guides/cli-automation",
               "guides/publish-to-npm"
             ]
           },

--- a/packages/docs/guides/cli-automation.mdx
+++ b/packages/docs/guides/cli-automation.mdx
@@ -1,0 +1,104 @@
+---
+title: CLI in CI & agents
+description: Run the Subframe CLI non-interactively from CI pipelines and AI coding agents.
+---
+
+The Subframe CLI normally prompts for anything it's missing. When stdin is not a
+TTY — in CI, a Docker build, or an AI coding agent — it switches to
+**non-interactive mode** automatically: instead of hanging on a prompt it uses
+the value from a flag, falls back to a safe default, or exits non-zero with a
+message telling you exactly which flag to pass.
+
+You can also force this mode in an interactive terminal with `--yes`.
+
+## Authentication
+
+Provide a token without the interactive login. Generate one from the
+[CLI auth page ↗](https://app.subframe.com/cli/auth).
+
+<Tabs>
+  <Tab title="Environment variable (recommended)">
+    Preferred for CI and agents — the token never appears in the process list or
+    shell history.
+
+    ```bash
+    export SUBFRAME_AUTH_TOKEN="<your-token>"
+    npx @subframe/cli@latest sync --all
+    ```
+  </Tab>
+  <Tab title="Flag">
+    ```bash
+    npx @subframe/cli@latest sync --all --auth-token "<your-token>"
+    ```
+  </Tab>
+</Tabs>
+
+The `--auth-token` flag takes precedence over `SUBFRAME_AUTH_TOKEN` if both are
+set. Either is verified and cached on first use, so later commands in the same
+environment reuse it without re-supplying or re-verifying it.
+
+## Global flags
+
+| Flag | Description |
+| --- | --- |
+| `-y, --yes` | Accept the safe defaults and never prompt. Implied automatically when stdin is not a TTY. |
+| `--non-interactive` | Strict mode: never prompt **and** never assume a default — fail if any required value is missing. Use this when you want a run to error rather than guess. |
+| `--json` | Print a machine-readable JSON result to stdout. Human logs go to stderr. Implies non-interactive. |
+
+Every command exits non-zero on failure (and, with `--json`, prints an
+`{ "ok": false, "error": ... }` envelope to stdout), so you can rely on either
+the exit code or the JSON in a pipeline.
+
+## Examples
+
+### Sync components in CI
+
+The most common case. After `init` has been run once and committed
+`.subframe/sync.json`, syncing only needs a token:
+
+```bash
+SUBFRAME_AUTH_TOKEN="<your-token>" npx @subframe/cli@latest sync --all
+```
+
+### Initialize an existing project non-interactively
+
+Pass the values the CLI would otherwise prompt for:
+
+```bash
+SUBFRAME_AUTH_TOKEN="<your-token>" npx @subframe/cli@latest init \
+  --yes \
+  --projectId <projectId> \
+  --css-type tailwind-v4 \
+  --dir ./src \
+  --css-path ./src/app/globals.css \
+  --no-install
+```
+
+`init` flags worth knowing:
+
+- `--projectId <id>` — required when your account has more than one project (otherwise the CLI can't choose for you and will list the available ids).
+- `--css-type <tailwind|tailwind-v4>` — required if the CLI can't detect your Tailwind version.
+- `--dir <path>` — where components sync to.
+- `--alias <alias>` — the import alias to use. Must end with `/*` (e.g. `@/ui/*`) so it matches every file in the directory; the CLI rejects an alias without it.
+- `--no-install`, `--no-sync`, `--no-tailwind` — skip a step that would otherwise prompt. The matching `--install` / `--sync` / `--tailwind` force it on.
+- `--no-update-import-alias` — don't change the import alias stored in your Subframe project.
+
+### Scaffold a brand new project
+
+Creating a project from scratch can't guess your framework or name, so pass them:
+
+```bash
+SUBFRAME_AUTH_TOKEN="<your-token>" npx @subframe/cli@latest init \
+  --template nextjs \
+  --name my-app \
+  --projectId <projectId>
+```
+
+### Parse the result
+
+With `--json`, stdout carries only the result object:
+
+```bash
+npx @subframe/cli@latest sync --all --json
+# { "ok": true, "command": "sync", "projectId": "...", "components": "all", ... }
+```

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -53,3 +53,18 @@ export const COMMAND_CSS_TYPE_KEY = "--css-type"
 export const COMMAND_CSS_TYPE_KEY_SHORT = "-c"
 export const COMMAND_CSS_PATH_KEY = "--css-path"
 export const COMMAND_CSS_PATH_KEY_SHORT = "-x"
+
+// Negated forms of the boolean step flags, so a step can be forced off without a prompt.
+export const COMMAND_NO_INSTALL_KEY = "--no-install"
+export const COMMAND_NO_SYNC_KEY = "--no-sync"
+export const COMMAND_NO_TAILWIND_KEY = "--no-tailwind"
+export const COMMAND_UPDATE_IMPORT_ALIAS_KEY = "--update-import-alias"
+export const COMMAND_NO_UPDATE_IMPORT_ALIAS_KEY = "--no-update-import-alias"
+
+// Global, cross-command flags. These are read directly from argv (see the CLI's
+// flags.ts) in addition to being registered with commander, so both spots must
+// reference the same constant.
+export const COMMAND_YES_KEY = "--yes"
+export const COMMAND_YES_KEY_SHORT = "-y"
+export const COMMAND_NON_INTERACTIVE_KEY = "--non-interactive"
+export const COMMAND_JSON_KEY = "--json"

--- a/packages/subframe-cli/package.json
+++ b/packages/subframe-cli/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "test:e2e": "npm run build-for-publish && vitest run --config vitest.e2e.config.ts",
     "build-for-publish": "rollup -c --bundleConfigAsCjs",
     "dev": "rollup -c --bundleConfigAsCjs --watch",
     "update-version": "npm version minor",

--- a/packages/subframe-cli/package.json
+++ b/packages/subframe-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subframe/cli",
-  "version": "1.208.0",
+  "version": "1.209.0",
   "description": "Subframe's CLI tool for syncing your code with Subframe designs.",
   "repository": {
     "type": "git",

--- a/packages/subframe-cli/src/access-token.ts
+++ b/packages/subframe-cli/src/access-token.ts
@@ -3,7 +3,9 @@ import prompt from "prompts"
 import { CLI_AUTH_ROUTE } from "shared/routes"
 import { apiVerifyToken } from "./api-endpoints"
 import { BASE_URL } from "./common"
-import { getToken, storeToken } from "./config"
+import { getTeamIdForToken, getToken, storeToken } from "./config"
+import { SUBFRAME_AUTH_TOKEN_ENV } from "./constants"
+import { isNonInteractive, NonInteractiveError } from "./interactive"
 import { CLILogger } from "./logger/logger-cli"
 import { link } from "./output/format"
 import { abortOnState } from "./prompt-helpers"
@@ -37,6 +39,15 @@ export async function verifyTokenWithOra(cliLogger: CLILogger, token: string): P
 }
 
 export async function promptForNewAccessToken(cliLogger: CLILogger): Promise<TokenWithTeam> {
+  // Without a TTY there is nobody to paste a token, so fail with guidance rather
+  // than hang on a prompt that can never be answered.
+  if (isNonInteractive()) {
+    throw new NonInteractiveError(
+      `No Subframe credentials found. Set the ${SUBFRAME_AUTH_TOKEN_ENV} environment variable ` +
+        `or pass --auth-token <token>. Generate a token at ${BASE_URL}${CLI_AUTH_ROUTE}.`,
+    )
+  }
+
   console.log("> To get new credentials, please visit the following URL in your web browser:")
   console.log(`> ${link(`${BASE_URL}${CLI_AUTH_ROUTE}`)}`)
   console.log()
@@ -81,4 +92,50 @@ export async function getAccessToken(cliLogger: CLILogger, { teamId }: { teamId?
   }
 
   return promptForNewAccessToken(cliLogger)
+}
+
+/**
+ * Resolve a token supplied out-of-band (flag or env var). If it's already cached
+ * from a previous run, reuse it without another verify round-trip; otherwise
+ * verify it once and cache it. `source` names where it came from for errors.
+ */
+async function resolveSuppliedToken(cliLogger: CLILogger, token: string, source: string): Promise<TokenWithTeam> {
+  const cachedTeamId = await getTeamIdForToken(cliLogger, token)
+  if (cachedTeamId !== null) {
+    return { token, teamId: cachedTeamId }
+  }
+
+  const verified = await verifyTokenWithOra(cliLogger, token)
+  if (!verified) {
+    throw new Error(`Failed to authenticate with ${source}`)
+  }
+  await storeToken(cliLogger, verified)
+  return verified
+}
+
+/**
+ * Resolve an access token for any command, in priority order:
+ *
+ * 1. an explicit `--auth-token` flag
+ * 2. the {@link SUBFRAME_AUTH_TOKEN_ENV} environment variable (preferred for CI/agents)
+ * 3. a previously cached token for `teamId`, otherwise an interactive prompt
+ *    (which fails fast in non-interactive mode)
+ *
+ * A token from (1) or (2) is verified and cached on first use so subsequent
+ * commands work without re-supplying it (and without re-verifying it).
+ */
+export async function resolveAccessToken(
+  cliLogger: CLILogger,
+  { authTokenFlag, teamId }: { authTokenFlag?: string; teamId?: number },
+): Promise<TokenWithTeam> {
+  if (authTokenFlag) {
+    return resolveSuppliedToken(cliLogger, authTokenFlag, "the provided --auth-token")
+  }
+
+  const envToken = process.env[SUBFRAME_AUTH_TOKEN_ENV]
+  if (envToken) {
+    return resolveSuppliedToken(cliLogger, envToken, `the token in ${SUBFRAME_AUTH_TOKEN_ENV}`)
+  }
+
+  return getAccessToken(cliLogger, { teamId })
 }

--- a/packages/subframe-cli/src/common.ts
+++ b/packages/subframe-cli/src/common.ts
@@ -12,11 +12,11 @@ export const isBeta = !isDev && process.argv.includes("--beta")
 
 // The base URL of the Subframe backend for the selected environment.
 // This is the single source of truth used by all API calls.
-export const BASE_URL = isDev
-  ? "http://localhost:6501"
-  : isBeta
-    ? "https://beta.subframe.com"
-    : "https://app.subframe.com"
+// SUBFRAME_BASE_URL overrides everything (used for tests and self-hosted/staging
+// backends); otherwise --dev/--beta select the environment.
+export const BASE_URL =
+  process.env.SUBFRAME_BASE_URL ||
+  (isDev ? "http://localhost:6501" : isBeta ? "https://beta.subframe.com" : "https://app.subframe.com")
 
 export const cwd = process.cwd()
 

--- a/packages/subframe-cli/src/config.ts
+++ b/packages/subframe-cli/src/config.ts
@@ -49,12 +49,34 @@ export async function getToken(cliLogger: CLILogger, { teamId }: { teamId: numbe
   return config?.tokens[teamId] ?? null
 }
 
+/**
+ * Look up the team a token is already cached under, if any. Lets callers reuse a
+ * previously-verified token without another round-trip to the verify endpoint.
+ */
+export async function getTeamIdForToken(cliLogger: CLILogger, token: string): Promise<number | null> {
+  const config = await readAuthConfig(cliLogger)
+  if (!config) {
+    return null
+  }
+  for (const [teamId, cachedToken] of Object.entries(config.tokens)) {
+    if (cachedToken === token) {
+      return Number(teamId)
+    }
+  }
+  return null
+}
+
 export async function storeToken(
   cliLogger: CLILogger,
   { teamId, token }: { teamId: number; token: string },
 ): Promise<void> {
   const config = await readAuthConfig(cliLogger)
   const tokens = config?.tokens ?? {}
+  // Avoid a redundant read-modify-write (and the file race under concurrent jobs)
+  // when the cached token is already identical.
+  if (tokens[teamId] === token) {
+    return
+  }
   tokens[teamId] = token
   await writeAuthConfig({ tokens })
 }

--- a/packages/subframe-cli/src/constants.ts
+++ b/packages/subframe-cli/src/constants.ts
@@ -1,4 +1,11 @@
 /**
+ * Environment variable used to supply an access token non-interactively.
+ * Preferred over the --auth-token flag for CI/agents since it doesn't leak the
+ * token into the process list or shell history.
+ */
+export const SUBFRAME_AUTH_TOKEN_ENV = "SUBFRAME_AUTH_TOKEN"
+
+/**
  * Packages included in this list will be automatically installed
  * when running the CLI (if they are not already installed)
  */

--- a/packages/subframe-cli/src/flags.ts
+++ b/packages/subframe-cli/src/flags.ts
@@ -1,0 +1,24 @@
+/**
+ * Global flags parsed directly from argv.
+ *
+ * These are read from argv (not from commander's parsed options) so they're
+ * available at module-load time and regardless of where they appear relative to
+ * the subcommand. This is the single source of truth for the cross-cutting
+ * flags; `interactive.ts` and `output/output.ts` derive their behavior from
+ * here rather than each re-scanning argv.
+ *
+ * (The environment flags --dev/--beta live in common.ts because they also gate
+ * BASE_URL and the telemetry env; they are intentionally not duplicated here.)
+ */
+import {
+  COMMAND_JSON_KEY,
+  COMMAND_NON_INTERACTIVE_KEY,
+  COMMAND_YES_KEY,
+  COMMAND_YES_KEY_SHORT,
+} from "shared/constants"
+
+const argv = process.argv
+
+export const flagYes = argv.includes(COMMAND_YES_KEY) || argv.includes(COMMAND_YES_KEY_SHORT)
+export const flagNonInteractive = argv.includes(COMMAND_NON_INTERACTIVE_KEY)
+export const flagJson = argv.includes(COMMAND_JSON_KEY)

--- a/packages/subframe-cli/src/import.ts
+++ b/packages/subframe-cli/src/import.ts
@@ -3,13 +3,12 @@ import { readFile } from "node:fs/promises"
 import { oraPromise } from "ora"
 import { COMMAND_AUTH_TOKEN_KEY, COMMAND_AUTH_TOKEN_KEY_SHORT } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
-import { getAccessToken, verifyTokenWithOra } from "./access-token"
+import { resolveAccessToken } from "./access-token"
 import { apiCreateImportSession, apiStartImport, uploadToPresignedUrl } from "./api-endpoints"
 import { localSyncSettings } from "./common"
-import { storeToken } from "./config"
 import { resolveManifest } from "./import-manifest"
-import { makeCLILogger } from "./logger/logger-cli"
 import { success } from "./output/format"
+import { runCommand } from "./run-command"
 
 const PAYLOAD_SIZE_LIMIT = 50 * 1024 * 1024 // 50MB
 
@@ -19,21 +18,12 @@ export const importCommand = new Command()
   .requiredOption("-p, --project-id <projectId>", "Subframe project ID")
   .requiredOption("-m, --manifest <path>", "path to import manifest JSON")
   .option(`${COMMAND_AUTH_TOKEN_KEY_SHORT}, ${COMMAND_AUTH_TOKEN_KEY} <auth-token>`, "auth token to use")
-  .action(async (opts) => {
-    const cliLogger = makeCLILogger()
-
-    try {
-      let accessToken = opts.authToken
-      if (accessToken) {
-        const tokenWithTeam = await verifyTokenWithOra(cliLogger, accessToken)
-        if (!tokenWithTeam) {
-          throw new Error("Failed to authenticate with provided token")
-        }
-        await storeToken(cliLogger, tokenWithTeam)
-      } else {
-        const tokenWithTeam = await getAccessToken(cliLogger, { teamId: localSyncSettings?.teamId })
-        accessToken = tokenWithTeam.token
-      }
+  .action(async (opts) =>
+    runCommand("import", async (cliLogger) => {
+      const { token: accessToken } = await resolveAccessToken(cliLogger, {
+        authTokenFlag: opts.authToken,
+        teamId: localSyncSettings?.teamId,
+      })
 
       const manifestRaw = await readFile(opts.manifest, "utf8")
       let manifestParsed: unknown
@@ -84,9 +74,7 @@ export const importCommand = new Command()
       )
 
       console.log(`\n  ${success("Design system uploaded. Import is now in progress.")}`)
-    } catch (err: any) {
-      await cliLogger.trackWarningAndFlush("[CLI]: import uncaught error", { error: err.toString() })
-      console.error(err)
-      process.exit(1)
-    }
-  })
+
+      return { projectId: opts.projectId, sessionId }
+    }),
+  )

--- a/packages/subframe-cli/src/index.ts
+++ b/packages/subframe-cli/src/index.ts
@@ -1,12 +1,31 @@
 import { program } from "@commander-js/extra-typings"
+import {
+  COMMAND_JSON_KEY,
+  COMMAND_NON_INTERACTIVE_KEY,
+  COMMAND_YES_KEY,
+  COMMAND_YES_KEY_SHORT,
+} from "shared/constants"
 import packageJson from "../package.json"
 import { isBeta, isDev } from "./common"
 import { importCommand } from "./import"
 import { initCommand } from "./init"
+import { configureOutput } from "./output/output"
 import { pushComponentCommand } from "./push-component"
 import { syncCommand } from "./sync"
 
 program.version(packageJson.version).description("Subframe CLI")
+
+// Global flags for non-interactive / automated use. These are read directly
+// from argv (see ./flags) so they work whether they appear before or after the
+// subcommand; registering them here keeps commander from rejecting them and
+// surfaces them in `subframe --help`.
+program
+  .option(`${COMMAND_YES_KEY_SHORT}, ${COMMAND_YES_KEY}`, "accept defaults and never prompt (also implied when stdin is not a TTY)")
+  .option(COMMAND_NON_INTERACTIVE_KEY, "strict: never prompt and never assume defaults; fail if a required value is missing")
+  .option(COMMAND_JSON_KEY, "print a machine-readable JSON result on stdout")
+
+// Route human chatter to stderr (and emit JSON results) when requested.
+configureOutput()
 
 if (isDev) {
   program.option("--dev")

--- a/packages/subframe-cli/src/init-project.ts
+++ b/packages/subframe-cli/src/init-project.ts
@@ -1,9 +1,11 @@
 import { oraPromise } from "ora"
 import prompts from "prompts"
 import { FAILED_TO_FETCH_PROJECT_ERROR } from "shared/constants"
+import { COMMAND_PROJECT_ID_KEY } from "shared/constants"
 import { InitProjectResponse, TruncatedProjectId } from "shared/types"
 import { promptForNewAccessToken } from "./access-token"
 import { apiInitProject, apiListProjects } from "./api-endpoints"
+import { isNonInteractive, NonInteractiveError } from "./interactive"
 import { CLILogger } from "./logger/logger-cli"
 import { highlight } from "./output/format"
 import { abortOnState } from "./prompt-helpers"
@@ -37,6 +39,15 @@ export async function selectProject({
   if (projects.length === 1) {
     // Only one project - use it automatically
     return projects[0].truncatedProjectId
+  }
+
+  // Multiple projects, no way to choose without input - fail with the list so the
+  // caller knows exactly which id to pass. Never guess a project for them.
+  if (isNonInteractive()) {
+    const available = projects.map((p) => `  - ${p.name} (${p.truncatedProjectId})`).join("\n")
+    throw new NonInteractiveError(
+      `Multiple Subframe projects found. Pass ${COMMAND_PROJECT_ID_KEY} <projectId>.\nAvailable projects:\n${available}`,
+    )
   }
 
   // Multiple projects - prompt user to select one

--- a/packages/subframe-cli/src/init-sync.ts
+++ b/packages/subframe-cli/src/init-sync.ts
@@ -1,7 +1,7 @@
-import prompts from "prompts"
+import { COMMAND_NO_SYNC_KEY, COMMAND_SYNC_KEY } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
+import { ask } from "./interactive"
 import { CLILogger } from "./logger/logger-cli"
-import { abortOnState } from "./prompt-helpers"
 import { syncComponents } from "./sync-components"
 
 export async function initSync(
@@ -13,19 +13,17 @@ export async function initSync(
   cssType: "tailwind" | "tailwind-v4",
   opts: { sync?: boolean },
 ) {
-  prompts.override({
-    sync: opts.sync,
-  })
+  const shouldSync = await ask<boolean>(
+    {
+      type: "confirm",
+      name: "sync",
+      initial: true,
+      message: "Would you like to sync all of your Subframe components?",
+    },
+    { override: opts.sync, requiredHint: `Pass ${COMMAND_SYNC_KEY} or ${COMMAND_NO_SYNC_KEY}.` },
+  )
 
-  const response = await prompts({
-    type: "confirm",
-    name: "sync",
-    initial: true,
-    message: ["Would you like to sync all of your Subframe components?"].join("\n"),
-    onState: abortOnState,
-  })
-
-  if (!response.sync) {
+  if (!shouldSync) {
     return
   }
 

--- a/packages/subframe-cli/src/init.ts
+++ b/packages/subframe-cli/src/init.ts
@@ -2,7 +2,6 @@ import { Command, Option } from "@commander-js/extra-typings"
 import { writeFile } from "node:fs/promises"
 import path, { join } from "node:path"
 import { oraPromise } from "ora"
-import prompts from "prompts"
 import {
   COMMAND_ALIAS_KEY,
   COMMAND_ALIAS_KEY_SHORT,
@@ -18,6 +17,10 @@ import {
   COMMAND_INSTALL_KEY_SHORT,
   COMMAND_NAME_KEY,
   COMMAND_NAME_KEY_SHORT,
+  COMMAND_NO_INSTALL_KEY,
+  COMMAND_NO_SYNC_KEY,
+  COMMAND_NO_TAILWIND_KEY,
+  COMMAND_NO_UPDATE_IMPORT_ALIAS_KEY,
   COMMAND_PROJECT_ID_KEY,
   COMMAND_PROJECT_ID_KEY_SHORT,
   COMMAND_SYNC_KEY,
@@ -25,18 +28,19 @@ import {
   COMMAND_TAILWIND_KEY,
   COMMAND_TAILWIND_KEY_SHORT,
   COMMAND_TEMPLATE_KEY,
+  COMMAND_UPDATE_IMPORT_ALIAS_KEY,
   DEFAULT_SUBFRAME_TS_ALIAS,
 } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
-import { getAccessToken, verifyTokenWithOra } from "./access-token"
+import { resolveAccessToken } from "./access-token"
 import { apiUpdateImportAlias } from "./api-endpoints"
 import { localSyncSettings } from "./common"
-import { storeToken } from "./config"
 import { SUBFRAME_INIT_MESSAGE } from "./constants"
 import { initProject, selectProject } from "./init-project"
 import { initSync } from "./init-sync"
 import { installDependencies } from "./install-dependencies"
-import { makeCLILogger } from "./logger/logger-cli"
+import { ask } from "./interactive"
+import { runCommand } from "./run-command"
 import { prepareProject } from "./setup/prepare-project"
 import { setupTailwindV3 } from "./setup-tailwind-v3"
 import { setupTailwindV4 } from "./setup-tailwind-v4"
@@ -65,6 +69,11 @@ export const initCommand = new Command()
   .option(`${COMMAND_TAILWIND_KEY_SHORT}, ${COMMAND_TAILWIND_KEY}`, "setup tailwind with Subframe theme")
   .option(`${COMMAND_ALIAS_KEY_SHORT}, ${COMMAND_ALIAS_KEY} <alias>`, "import alias to use")
   .option(`${COMMAND_SYNC_KEY_SHORT}, ${COMMAND_SYNC_KEY}`, "sync all components")
+  .option(COMMAND_NO_SYNC_KEY, "skip syncing components")
+  .option(COMMAND_NO_INSTALL_KEY, "skip installing dependencies")
+  .option(COMMAND_NO_TAILWIND_KEY, "skip configuring Tailwind")
+  .option(COMMAND_UPDATE_IMPORT_ALIAS_KEY, "update the import alias in your Subframe project when it changed")
+  .option(COMMAND_NO_UPDATE_IMPORT_ALIAS_KEY, "keep the existing import alias in your Subframe project")
   .addOption(
     new Option(`${COMMAND_CSS_TYPE_KEY_SHORT}, ${COMMAND_CSS_TYPE_KEY} <cssType>`, "css type to use").choices([
       "tailwind",
@@ -76,23 +85,22 @@ export const initCommand = new Command()
     "path to global CSS file (used for Tailwind v4, and for Tailwind v3 when dark mode is enabled)",
   )
 
-initCommand.action(async (opts) => {
-  const cliLogger = makeCLILogger()
+initCommand.action(async (opts) =>
+  runCommand("init", async (cliLogger) => {
+    // A flag-provided alias bypasses the interactive prompt (and its validation)
+    // because init pre-fills it into the sync settings, so validate it up front.
+    if (opts.alias && !opts.alias.endsWith(TS_ALIAS_SUFFIX)) {
+      throw new Error(
+        `--alias must end with '${TS_ALIAS_SUFFIX}' so that it matches all files in the directory (e.g. ${opts.alias}${TS_ALIAS_SUFFIX})`,
+      )
+    }
 
-  try {
     const { projectPath, didCreateNewProject, styleInfo } = await prepareProject(cliLogger, opts)
 
-    let accessToken = opts.authToken
-    if (accessToken) {
-      const tokenWithTeam = await verifyTokenWithOra(cliLogger, accessToken)
-      if (!tokenWithTeam) {
-        throw new Error("Failed to authenticate with provided token")
-      }
-      await storeToken(cliLogger, tokenWithTeam)
-    } else {
-      const tokenWithTeam = await getAccessToken(cliLogger, { teamId: localSyncSettings?.teamId })
-      accessToken = tokenWithTeam.token
-    }
+    const { token: accessToken } = await resolveAccessToken(cliLogger, {
+      authTokenFlag: opts.authToken,
+      teamId: localSyncSettings?.teamId,
+    })
 
     console.time(SUBFRAME_INIT_MESSAGE)
 
@@ -146,12 +154,18 @@ initCommand.action(async (opts) => {
     if (oldImportAlias !== importAlias) {
       console.log(`Change in import alias detected. Before: "${oldImportAlias}", After: "${importAlias}"`)
 
-      const { confirmUpdate } = await prompts({
-        type: "confirm",
-        name: "confirmUpdate",
-        message: `Update import alias in your Subframe project? Code will now use the new import alias: import { Button } from "${importAlias}/components/Button";`,
-        initial: true,
-      })
+      const confirmUpdate = await ask<boolean>(
+        {
+          type: "confirm",
+          name: "confirmUpdate",
+          message: `Update import alias in your Subframe project? Code will now use the new import alias: import { Button } from "${importAlias}/components/Button";`,
+          initial: true,
+        },
+        {
+          override: opts.updateImportAlias,
+          requiredHint: `Pass ${COMMAND_UPDATE_IMPORT_ALIAS_KEY} or ${COMMAND_NO_UPDATE_IMPORT_ALIAS_KEY}.`,
+        },
+      )
 
       if (confirmUpdate) {
         try {
@@ -209,8 +223,14 @@ initCommand.action(async (opts) => {
       }
       console.log(`  ${getRunDevCommand(packageManager).join(" ")}`)
     }
-  } catch (err: any) {
-    console.error(err)
-    await cliLogger.trackWarningAndFlush("[CLI] init: uncaught error", { error: err.toString() })
-  }
-})
+
+    return {
+      projectId: truncatedProjectId,
+      directory,
+      importAlias,
+      cssType: styleInfo.cssType,
+      didCreateNewProject,
+      didInstall,
+    }
+  }),
+)

--- a/packages/subframe-cli/src/install-dependencies.ts
+++ b/packages/subframe-cli/src/install-dependencies.ts
@@ -1,9 +1,9 @@
 import { execa } from "execa"
 import { oraPromise } from "ora"
-import prompts from "prompts"
 import { coerce, lt } from "semver"
+import { COMMAND_INSTALL_KEY, COMMAND_NO_INSTALL_KEY } from "shared/constants"
 import { AUTOINSTALLED_DEPENDENCIES } from "./constants"
-import { abortOnState } from "./prompt-helpers"
+import { ask } from "./interactive"
 import {
   getInstallCommand,
   getInstalledPackageVersion,
@@ -53,19 +53,17 @@ export async function installDependencies(
     makePackageSpecifier(packageName, packageVersion),
   )
 
-  prompts.override({
-    install: opts.install,
-  })
+  const shouldInstall = await ask<boolean>(
+    {
+      type: "confirm",
+      name: "install",
+      initial: true,
+      message: "Would you like to install dependencies?",
+    },
+    { override: opts.install, requiredHint: `Pass ${COMMAND_INSTALL_KEY} or ${COMMAND_NO_INSTALL_KEY}.` },
+  )
 
-  const response = await prompts({
-    type: "confirm",
-    name: "install",
-    initial: true,
-    message: ["Would you like to install dependencies?"].join("\n"),
-    onState: abortOnState,
-  })
-
-  if (!response.install) {
+  if (!shouldInstall) {
     return { didInstall: false }
   }
 

--- a/packages/subframe-cli/src/interactive.spec.ts
+++ b/packages/subframe-cli/src/interactive.spec.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ask, isNonInteractive, NonInteractiveError } from "./interactive"
+
+// Under vitest, process.stdin.isTTY is undefined, so isNonInteractive() is true.
+// These tests therefore exercise the non-interactive code paths of ask().
+
+describe("isNonInteractive", () => {
+  it("is true when stdin is not a TTY (the test environment)", () => {
+    expect(isNonInteractive()).toBe(true)
+  })
+})
+
+describe("ask (non-interactive)", () => {
+  it("returns an explicit override without prompting", async () => {
+    const value = await ask<string>(
+      { type: "text", name: "dir", message: "dir?", initial: "./src" },
+      { override: "./custom" },
+    )
+    expect(value).toBe("./custom")
+  })
+
+  it("returns false as an override (override of a falsy value still wins)", async () => {
+    const value = await ask<boolean>(
+      { type: "confirm", name: "install", message: "install?", initial: true },
+      { override: false },
+    )
+    expect(value).toBe(false)
+  })
+
+  it("falls back to a confirm's default when no override is given", async () => {
+    const value = await ask<boolean>({ type: "confirm", name: "install", message: "install?", initial: true })
+    expect(value).toBe(true)
+  })
+
+  it("falls back to a select's default choice value", async () => {
+    const value = await ask<string>({
+      type: "select",
+      name: "cssType",
+      message: "which?",
+      initial: 1,
+      choices: [
+        { title: "v3", value: "tailwind" },
+        { title: "v4", value: "tailwind-v4" },
+      ],
+    })
+    expect(value).toBe("tailwind-v4")
+  })
+
+  it("applies a text default's format function", async () => {
+    const value = await ask<string>({
+      type: "text",
+      name: "name",
+      message: "name?",
+      initial: "  my-app  ",
+      format: (v: string) => v.trim(),
+    })
+    expect(value).toBe("my-app")
+  })
+
+  it("throws NonInteractiveError when required and no override is provided", async () => {
+    await expect(
+      ask<string>(
+        { type: "text", name: "name", message: "name?", initial: "my-app" },
+        { required: true, requiredHint: "Pass --name <name>." },
+      ),
+    ).rejects.toBeInstanceOf(NonInteractiveError)
+  })
+
+  it("throws when there is no default and no override", async () => {
+    await expect(ask<string>({ type: "text", name: "token", message: "token?" })).rejects.toBeInstanceOf(
+      NonInteractiveError,
+    )
+  })
+
+  it("validates the default and throws the validation message when it fails", async () => {
+    await expect(
+      ask<string>({
+        type: "text",
+        name: "dir",
+        message: "dir?",
+        initial: "./does-not-exist",
+        validate: (v: string) => (v === "./src" ? true : `Directory ${v} does not exist`),
+      }),
+    ).rejects.toThrow("Directory ./does-not-exist does not exist")
+  })
+
+  it("validates an override and throws when it fails (no longer accepted as-is)", async () => {
+    await expect(
+      ask<string>(
+        {
+          type: "text",
+          name: "alias",
+          message: "alias?",
+          validate: (v: string) => (v.endsWith("/*") ? true : "Alias must end with '/*'"),
+        },
+        { override: "@/ui" },
+      ),
+    ).rejects.toThrow("Alias must end with '/*'")
+  })
+
+  it("formats an override the way an interactive answer would be (e.g. trims)", async () => {
+    const value = await ask<string>(
+      { type: "text", name: "name", message: "name?", format: (v: string) => v.trim() },
+      { override: "  my-app  " },
+    )
+    expect(value).toBe("my-app")
+  })
+})
+
+describe("ask (strict mode, --non-interactive)", () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock("./flags")
+  })
+
+  it("refuses to fall back to a default and fails fast", async () => {
+    vi.resetModules()
+    vi.doMock("./flags", () => ({ flagYes: false, flagNonInteractive: true, flagJson: false }))
+    const { ask: strictAsk, NonInteractiveError: StrictError } = await import("./interactive")
+
+    await expect(
+      strictAsk<boolean>(
+        { type: "confirm", name: "install", message: "install?", initial: true },
+        { requiredHint: "Pass --install or --no-install." },
+      ),
+    ).rejects.toBeInstanceOf(StrictError)
+  })
+
+  it("still honors an explicit override in strict mode", async () => {
+    vi.resetModules()
+    vi.doMock("./flags", () => ({ flagYes: false, flagNonInteractive: true, flagJson: false }))
+    const { ask: strictAsk } = await import("./interactive")
+
+    const value = await strictAsk<boolean>(
+      { type: "confirm", name: "install", message: "install?", initial: true },
+      { override: false },
+    )
+    expect(value).toBe(false)
+  })
+})

--- a/packages/subframe-cli/src/interactive.ts
+++ b/packages/subframe-cli/src/interactive.ts
@@ -1,0 +1,145 @@
+import prompts from "prompts"
+import { flagJson, flagNonInteractive, flagYes } from "./flags"
+import { abortOnState } from "./prompt-helpers"
+
+/**
+ * Whether the CLI should avoid interactive prompts.
+ *
+ * This is true when any of the following hold:
+ * - the user passed `--yes`/`-y` (accept defaults) or `--non-interactive` (strict)
+ * - the user asked for machine output (`--json`) — prompting would corrupt that
+ *   output, so we never prompt in that mode
+ * - stdin is not a TTY (e.g. CI, an AI agent, or a piped invocation)
+ *
+ * In non-interactive mode we never block on a prompt. Instead we use the value
+ * from a flag if provided, fall back to a safe default when one exists, or fail
+ * fast with an actionable error telling the caller which flag to pass.
+ */
+export function isNonInteractive(): boolean {
+  return flagYes || flagNonInteractive || flagJson || !process.stdin.isTTY
+}
+
+/**
+ * Strict mode (`--non-interactive`): never fall back to a default. Every value
+ * must come from a flag, or the command fails telling you which flag is missing.
+ * Plain `--yes` / a non-TTY stay lenient and accept the safe defaults.
+ */
+export function isStrict(): boolean {
+  return flagNonInteractive
+}
+
+/**
+ * Thrown when a value is required but cannot be obtained without prompting.
+ * The message is written for a human or agent reading CLI output, so it should
+ * name the flag (or env var) that would unblock the command.
+ */
+export class NonInteractiveError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "NonInteractiveError"
+  }
+}
+
+type Question = prompts.PromptObject<string>
+
+function resolveDefault(question: Question): unknown {
+  switch (question.type) {
+    case "confirm":
+      return question.initial ?? false
+    case "text":
+    case "password":
+    case "invisible":
+      return typeof question.initial === "string" ? question.initial : undefined
+    case "select":
+    case "autocomplete": {
+      const choices = question.choices as prompts.Choice[] | undefined
+      if (!choices || choices.length === 0) {
+        return undefined
+      }
+      const initial = typeof question.initial === "number" ? question.initial : 0
+      return choices[initial]?.value
+    }
+    default:
+      return question.initial
+  }
+}
+
+export interface AskOptions {
+  /**
+   * Value supplied via a CLI flag. When defined it is used directly and no
+   * prompt is shown (in interactive or non-interactive mode).
+   */
+  override?: unknown
+  /**
+   * When true, the question has no safe default: in non-interactive mode we
+   * throw instead of guessing. Use this for choices where picking wrong is
+   * costly (which project, which framework, the project name).
+   */
+  required?: boolean
+  /**
+   * Error message shown in non-interactive mode when no override/default is
+   * available. Should tell the caller which flag or env var to provide.
+   */
+  requiredHint?: string
+}
+
+/**
+ * Run a question's own `validate` (and `format`) against a value the same way an
+ * interactive answer would be checked, so a bad flag value or default fails with
+ * the question's error message instead of silently flowing downstream.
+ * The prompts callable types take extra (values, prompt) args we don't pass.
+ */
+async function validateAndFormat<T>(question: Question, value: unknown, fallbackMessage: string): Promise<T> {
+  const validate = question.validate as ((value: unknown) => boolean | string | Promise<boolean | string>) | undefined
+  if (typeof validate === "function") {
+    const validation = await validate(value)
+    if (validation !== true) {
+      throw new NonInteractiveError(typeof validation === "string" ? validation : fallbackMessage)
+    }
+  }
+
+  const format = question.format as ((value: unknown) => unknown) | undefined
+  if (typeof format === "function") {
+    return (await format(value)) as T
+  }
+  return value as T
+}
+
+/**
+ * Ask a single `prompts` question, honoring non-interactive mode.
+ *
+ * Resolution order:
+ * 1. an explicit `override` (from a flag) is validated/normalized the same way an
+ *    interactive answer would be, then used
+ * 2. in non-interactive mode, the question's default is used and validated —
+ *    unless `required`, or strict mode (`--non-interactive`), in which case a
+ *    missing value fails fast with an actionable hint
+ * 3. otherwise the user is prompted interactively
+ *
+ * Returns the answer value directly (not the `{ [name]: value }` wrapper).
+ */
+export async function ask<T = unknown>(question: Question, options: AskOptions = {}): Promise<T> {
+  const name = question.name as string
+  const invalidMessage = options.requiredHint ?? `Invalid value for "${name}".`
+
+  if (options.override !== undefined) {
+    return validateAndFormat<T>(question, options.override, invalidMessage)
+  }
+
+  if (isNonInteractive()) {
+    const fallback = options.required || isStrict() ? undefined : resolveDefault(question)
+
+    if (fallback === undefined) {
+      throw new NonInteractiveError(
+        options.requiredHint ??
+          `"${name}" is required, but no value was provided and the terminal is non-interactive. ` +
+            `Pass the corresponding flag, or run in an interactive terminal.`,
+      )
+    }
+
+    return validateAndFormat<T>(question, fallback, invalidMessage)
+  }
+
+  const answers = await prompts({ ...question, onState: abortOnState })
+  return answers[name] as T
+}

--- a/packages/subframe-cli/src/output/output.ts
+++ b/packages/subframe-cli/src/output/output.ts
@@ -1,0 +1,38 @@
+/**
+ * Machine-readable output handling for `--json`.
+ *
+ * In `--json` mode we route human-facing `console.log` chatter (and the timing
+ * helpers) to stderr so that stdout carries only the structured result, written
+ * via {@link emitResult}.
+ *
+ * Note: spinners (ora) already write to stderr and disable their animation when
+ * stdout is not a TTY, so they don't pollute the JSON result.
+ */
+import { flagJson } from "../flags"
+
+export const isJsonOutput = flagJson
+
+/**
+ * Redirect human-facing stdout chatter to stderr so that stdout carries only the
+ * structured JSON result. Call once at startup.
+ */
+export function configureOutput(): void {
+  if (!isJsonOutput) {
+    return
+  }
+  const toStderr = console.error.bind(console)
+  console.log = (...args: unknown[]) => toStderr(...args)
+  // Timing helpers default to stdout; neutralize them so they don't break JSON.
+  console.time = () => {}
+  console.timeEnd = () => {}
+}
+
+/**
+ * Emit a command's final result. In `--json` mode this writes the object to
+ * stdout as JSON; otherwise it does nothing (the command's own logging stands).
+ */
+export function emitResult(result: Record<string, unknown>): void {
+  if (isJsonOutput) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+  }
+}

--- a/packages/subframe-cli/src/push-component.ts
+++ b/packages/subframe-cli/src/push-component.ts
@@ -2,25 +2,27 @@ import { Command } from "@commander-js/extra-typings"
 import { readFile } from "node:fs/promises"
 import { isAbsolute, join } from "node:path"
 import { oraPromise } from "ora"
+import { COMMAND_AUTH_TOKEN_KEY, COMMAND_AUTH_TOKEN_KEY_SHORT } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
-import { getAccessToken } from "./access-token"
+import { resolveAccessToken } from "./access-token"
 import { apiPushComponent } from "./api-endpoints"
 import { cwd, localSyncSettings } from "./common"
-import { makeCLILogger } from "./logger/logger-cli"
 import { highlight } from "./output/format"
+import { runCommand } from "./run-command"
 
 export const pushComponentCommand = new Command()
   .name("push-component")
   .description("pushes a component to Subframe [EXPERIMENTAL]")
   .argument("<component-file-path>", "path to the component file to push")
   .requiredOption("-p, --project-id <projectId>", "project ID to push the component to")
+  .option(`${COMMAND_AUTH_TOKEN_KEY_SHORT}, ${COMMAND_AUTH_TOKEN_KEY} <auth-token>`, "auth token to use")
   .option("-s, --skip-normalize", "skip normalizing the component file")
-  .action(async (componentFilePath, opts) => {
-    const cliLogger = makeCLILogger()
-
-    try {
-      const tokenWithTeam = await getAccessToken(cliLogger, { teamId: localSyncSettings?.teamId })
-      const accessToken = tokenWithTeam.token
+  .action(async (componentFilePath, opts) =>
+    runCommand("push-component", async (cliLogger) => {
+      const { token: accessToken } = await resolveAccessToken(cliLogger, {
+        authTokenFlag: opts.authToken,
+        teamId: localSyncSettings?.teamId,
+      })
 
       // read file from path
       const resolvedPath = isAbsolute(componentFilePath) ? componentFilePath : join(cwd, componentFilePath)
@@ -29,28 +31,23 @@ export const pushComponentCommand = new Command()
       // look for export statement for component name, e.g. "export const Button = ..."
       const componentName = componentFile.match(/export const (\w+) = /)?.[1]
       if (!componentName) {
-        console.log("Failed to find component name in component file")
-        return
+        throw new Error("Failed to find component name in component file")
       }
 
-      try {
-        await oraPromise(
-          apiPushComponent(accessToken, {
-            truncatedProjectId: opts.projectId as TruncatedProjectId,
-            componentName,
-            componentFile,
-            skipNormalize: opts.skipNormalize,
-          }),
-          {
-            text: "Pushing Subframe component",
-            successText: () => `Pushed component ${highlight(componentName)}`,
-            failText: (error: Error) => `Failed to push component ${highlight(componentName)}:\n${error.message}`,
-          },
-        )
-      } catch (err) {
-        // error is logged by oraPromise
-      }
-    } catch (err: any) {
-      await cliLogger.trackWarningAndFlush("[CLI]: push-component uncaught error", { error: err.toString() })
-    }
-  })
+      await oraPromise(
+        apiPushComponent(accessToken, {
+          truncatedProjectId: opts.projectId as TruncatedProjectId,
+          componentName,
+          componentFile,
+          skipNormalize: opts.skipNormalize,
+        }),
+        {
+          text: "Pushing Subframe component",
+          successText: () => `Pushed component ${highlight(componentName)}`,
+          failText: (error: Error) => `Failed to push component ${highlight(componentName)}:\n${error.message}`,
+        },
+      )
+
+      return { componentName, projectId: opts.projectId }
+    }),
+  )

--- a/packages/subframe-cli/src/run-command.ts
+++ b/packages/subframe-cli/src/run-command.ts
@@ -1,0 +1,36 @@
+import { CLILogger, makeCLILogger } from "./logger/logger-cli"
+import { emitResult } from "./output/output"
+
+/**
+ * Run a command action with uniform error handling and machine-readable output.
+ *
+ * - creates the CLI logger and hands it to `fn`
+ * - on success, emits `{ ok: true, command, ...result }` (only in --json mode)
+ * - on failure, prints the error message, records telemetry, emits
+ *   `{ ok: false, command, error }` (in --json mode), and exits non-zero
+ *
+ * Centralizing this keeps every command's success/error contract identical:
+ * one clean error line (never a stack), a non-zero exit code, and a structured
+ * JSON envelope on both success and failure.
+ */
+export async function runCommand(
+  command: string,
+  fn: (cliLogger: CLILogger) => Promise<Record<string, unknown> | void>,
+): Promise<void> {
+  const cliLogger = makeCLILogger()
+  try {
+    const result = await fn(cliLogger)
+    emitResult({ ok: true, command, ...(result ?? {}) })
+  } catch (err: any) {
+    const message = err?.message ?? String(err)
+    console.error(message)
+    // Never let a telemetry failure mask the real error or change the exit code.
+    try {
+      await cliLogger.trackWarningAndFlush(`[CLI]: ${command} uncaught error`, { error: String(err) })
+    } catch {
+      // ignore
+    }
+    emitResult({ ok: false, command, error: message })
+    process.exit(1)
+  }
+}

--- a/packages/subframe-cli/src/setup-tailwind-v3.ts
+++ b/packages/subframe-cli/src/setup-tailwind-v3.ts
@@ -1,9 +1,9 @@
 import { join } from "node:path"
 import ora from "ora"
-import prompts from "prompts"
+import { COMMAND_NO_TAILWIND_KEY, COMMAND_TAILWIND_KEY } from "shared/constants"
 import { CodeGenFileValid } from "shared/types"
 import { ObjectLiteralExpression, printNode, Project, QuoteKind, SourceFile, SyntaxKind } from "ts-morph"
-import { abortOnState } from "./prompt-helpers"
+import { ask } from "./interactive"
 import { injectThemeImportIntoGlobals } from "./setup/inject-theme-import"
 import { makeSubframeContentGlob, makeSubframeRequire } from "./transforms/tailwind"
 
@@ -76,17 +76,16 @@ export async function setupTailwindV3(
       ) !== -1
 
     if (!alreadyConfigured) {
-      prompts.override({
-        updateTailwindConfig: opts.tailwind,
-      })
-      const response = await prompts({
-        type: "confirm",
-        name: "updateTailwindConfig",
-        initial: true,
-        message: "Do you want Subframe to configure your Tailwind config?",
-        onState: abortOnState,
-      })
-      if (response.updateTailwindConfig) {
+      const updateTailwindConfig = await ask<boolean>(
+        {
+          type: "confirm",
+          name: "updateTailwindConfig",
+          initial: true,
+          message: "Do you want Subframe to configure your Tailwind config?",
+        },
+        { override: opts.tailwind, requiredHint: `Pass ${COMMAND_TAILWIND_KEY} or ${COMMAND_NO_TAILWIND_KEY}.` },
+      )
+      if (updateTailwindConfig) {
         const spinner = ora("Updating Tailwind config").start()
         transformTailwindConfigFile(tailwindConfig, cwd, subframeDirPath)
         await tailwindConfig.save()

--- a/packages/subframe-cli/src/setup/inject-theme-import.ts
+++ b/packages/subframe-cli/src/setup/inject-theme-import.ts
@@ -1,8 +1,7 @@
 import { readFile, writeFile } from "fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
-import prompts from "prompts"
-import { TAILWIND_CSS_EXPORT_FILENAME } from "shared/constants"
-import { abortOnState } from "../prompt-helpers"
+import { COMMAND_CSS_PATH_KEY, COMMAND_NO_TAILWIND_KEY, COMMAND_TAILWIND_KEY, TAILWIND_CSS_EXPORT_FILENAME } from "shared/constants"
+import { ask } from "../interactive"
 import { exists, posixJoin } from "../utils/fs"
 
 // Exported for testing
@@ -41,41 +40,43 @@ export async function injectThemeImportIntoGlobals({
   globalCssPath?: string
   tailwindOptInOverride?: boolean
 }): Promise<void> {
-  prompts.override({
-    updateTailwindConfig: tailwindOptInOverride,
-  })
+  const shouldUpdate = await ask<boolean>(
+    {
+      type: "confirm",
+      name: "updateTailwindConfig",
+      initial: true,
+      message: "Do you want Subframe to add the theme.css import to your global CSS file?",
+    },
+    { override: tailwindOptInOverride, requiredHint: `Pass ${COMMAND_TAILWIND_KEY} or ${COMMAND_NO_TAILWIND_KEY}.` },
+  )
 
-  const response = await prompts({
-    type: "confirm",
-    name: "updateTailwindConfig",
-    initial: true,
-    message: "Do you want Subframe to add the theme.css import to your global CSS file?",
-    onState: abortOnState,
-  })
-
-  if (!response.updateTailwindConfig) {
+  if (!shouldUpdate) {
     return
   }
 
-  const { globalCssPath: resolvedGlobalCssPath } = globalCssPath
-    ? { globalCssPath }
-    : await prompts({
-        type: "text",
-        name: "globalCssPath",
-        message: "What is the path to your global CSS file? (e.g., src/index.css, src/app/globals.css)",
-        initial: "src/index.css",
-        validate: async (value: string) => {
-          if (!value || value.trim().length === 0) {
-            return "Please provide a path to your global CSS file"
-          }
-          const fullPath = resolve(projectPath, value)
-          if (!(await exists(fullPath))) {
-            return `File not found: ${value}`
-          }
-          return true
-        },
-        onState: abortOnState,
-      })
+  const resolvedGlobalCssPath = await ask<string>(
+    {
+      type: "text",
+      name: "globalCssPath",
+      message: "What is the path to your global CSS file? (e.g., src/index.css, src/app/globals.css)",
+      initial: "src/index.css",
+      validate: async (value: string) => {
+        if (!value || value.trim().length === 0) {
+          return "Please provide a path to your global CSS file"
+        }
+        const fullPath = resolve(projectPath, value)
+        if (!(await exists(fullPath))) {
+          return `File not found: ${value}`
+        }
+        return true
+      },
+    },
+    {
+      override: globalCssPath,
+      required: true,
+      requiredHint: `Pass ${COMMAND_CSS_PATH_KEY} <path> to point at your global CSS file.`,
+    },
+  )
 
   const cssFilePath = join(projectPath, resolvedGlobalCssPath)
   const themeFilePath = join(subframeDirPath, TAILWIND_CSS_EXPORT_FILENAME)

--- a/packages/subframe-cli/src/setup/prepare-project.ts
+++ b/packages/subframe-cli/src/setup/prepare-project.ts
@@ -2,12 +2,12 @@ import { downloadTemplate } from "@bluwy/giget-core"
 import { readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import ora from "ora"
-import prompts from "prompts"
 import { coerce, gte } from "semver"
+import { COMMAND_CSS_TYPE_KEY, COMMAND_NAME_KEY, COMMAND_TEMPLATE_KEY } from "shared/constants"
 import { cwd } from "../common"
+import { ask } from "../interactive"
 import { CLILogger } from "../logger/logger-cli"
 import { highlight } from "../output/format"
-import { abortOnState } from "../prompt-helpers"
 import { exists } from "../utils/fs"
 import { tryGitInit } from "../utils/git"
 import { getInstalledPackageVersion } from "../utils/package-managers"
@@ -120,17 +120,7 @@ export async function prepareProject(
 ): Promise<{ projectPath: string; didCreateNewProject: boolean; styleInfo: StyleInfo }> {
   // No package.json in current directory - assume they need to set up a new project.
   if (options.template !== undefined || !(await exists(resolve(cwd, "package.json")))) {
-    prompts.override({
-      type: options.template,
-      name: options.name,
-      cssType: options.cssType,
-    })
-
-    // NOTE: We need to pre-validate the name if it was provided because otherwise the overrides will not work with the
-    // async validation function.
-    const providedNameValidateResult = options.name ? await validateName(options.name) : false
-
-    const { type, name, cssType } = await prompts([
+    const type = await ask<"nextjs" | "vite" | "astro">(
       {
         type: "select",
         name: "type",
@@ -143,17 +133,31 @@ export async function prepareProject(
           { title: "Astro", value: "astro" },
         ],
         initial: 0,
-        onState: abortOnState,
       },
+      {
+        override: options.template,
+        required: true,
+        requiredHint: `No package.json found here. Pass ${COMMAND_TEMPLATE_KEY} <vite|nextjs|astro> to scaffold a new project.`,
+      },
+    )
+
+    const name = await ask<string>(
       {
         type: "text",
         name: "name",
         message: "What is your project named?",
         initial: "my-app",
         format: (value: string) => value.trim(),
-        onState: abortOnState,
-        validate: options.name ? () => providedNameValidateResult : validateName,
+        validate: validateName,
       },
+      {
+        override: options.name,
+        required: true,
+        requiredHint: `Pass ${COMMAND_NAME_KEY} <name> to name the new project.`,
+      },
+    )
+
+    const cssType = await ask<"tailwind" | "tailwind-v4">(
       {
         type: "select",
         name: "cssType",
@@ -163,9 +167,9 @@ export async function prepareProject(
           { title: "Tailwind v4", value: "tailwind-v4" },
         ],
         initial: 0,
-        onState: abortOnState,
       },
-    ])
+      { override: options.cssType, requiredHint: `Pass ${COMMAND_CSS_TYPE_KEY} <tailwind|tailwind-v4>.` },
+    )
 
     const projectPath = await cloneStarterKit({ name, type, cssType })
     await cliLogger.trackEventAndFlush({ type: "cli:starter-kit_cloned", framework: type, cssType })
@@ -176,19 +180,24 @@ export async function prepareProject(
   }
 
   const incomingOrDetectedCssType = options.cssType ?? (await detectTailwindVersion(cwd))
-  const { cssType } = incomingOrDetectedCssType
-    ? { cssType: incomingOrDetectedCssType }
-    : await prompts({
-        type: "select",
-        name: "cssType",
-        message: "What version of Tailwind CSS are you using?",
-        choices: [
-          { title: "Tailwind v3", value: "tailwind" },
-          { title: "Tailwind v4", value: "tailwind-v4" },
-        ],
-        initial: 0,
-        onState: abortOnState,
-      })
+  const cssType = incomingOrDetectedCssType
+    ? incomingOrDetectedCssType
+    : await ask<"tailwind" | "tailwind-v4">(
+        {
+          type: "select",
+          name: "cssType",
+          message: "What version of Tailwind CSS are you using?",
+          choices: [
+            { title: "Tailwind v3", value: "tailwind" },
+            { title: "Tailwind v4", value: "tailwind-v4" },
+          ],
+          initial: 0,
+        },
+        {
+          required: true,
+          requiredHint: `Could not detect your Tailwind version. Pass ${COMMAND_CSS_TYPE_KEY} <tailwind|tailwind-v4>.`,
+        },
+      )
 
   return {
     projectPath: cwd,

--- a/packages/subframe-cli/src/sync-settings.ts
+++ b/packages/subframe-cli/src/sync-settings.ts
@@ -1,12 +1,11 @@
 import { existsSync, readFileSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import prompts from "prompts"
-import { DEFAULT_SUBFRAME_TS_ALIAS, ROOT_FOLDER_NAME } from "shared/constants"
+import { COMMAND_ALIAS_KEY, COMMAND_DIR_KEY, DEFAULT_SUBFRAME_TS_ALIAS, ROOT_FOLDER_NAME } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
 import { addAliasesToTSConfig, hasAliasSetup } from "./add-tsconfig-alias"
 import { ACCESS_TOKEN_FILENAME, SUBFRAME_DIR, SYNC_SETTINGS_FILENAME } from "./constants"
-import { abortOnState } from "./prompt-helpers"
+import { ask } from "./interactive"
 import { exists, isDirectory, posixJoin } from "./utils/fs"
 
 export const TS_ALIAS_SUFFIX = "/*"
@@ -74,48 +73,52 @@ export async function setupSyncSettings(
   }
 
   if (!options.directory) {
-    prompts.override({
-      directory: initOptions.dir,
-    })
-    const response = await prompts({
-      type: "text",
-      name: "directory",
-      initial: "./src",
-      message: "Where should the Subframe components be synced to?",
-      validate: (value) => {
-        return existsSync(join(cwd, value)) ? true : `Directory ${value} does not exist`
+    const directory = await ask<string>(
+      {
+        type: "text",
+        name: "directory",
+        initial: "./src",
+        message: "Where should the Subframe components be synced to?",
+        validate: (value) => {
+          return existsSync(join(cwd, value)) ? true : `Directory ${value} does not exist`
+        },
       },
-      onState: abortOnState,
-    })
+      {
+        override: initOptions.dir,
+        requiredHint: `Pass ${COMMAND_DIR_KEY} <path> to choose where components are synced.`,
+      },
+    )
 
     // NOTE: join will remove the trailing slash
-    config.directory = "./" + posixJoin(response.directory, ROOT_FOLDER_NAME)
+    config.directory = "./" + posixJoin(directory, ROOT_FOLDER_NAME)
   }
 
   if (!options.importAlias) {
-    prompts.override({
-      componentsDirAlias: initOptions.alias,
-    })
-    const response = await prompts({
-      type: "text",
-      name: "componentsDirAlias",
-      initial: `${DEFAULT_SUBFRAME_TS_ALIAS}${TS_ALIAS_SUFFIX}`,
-      message: `Configure an alias for the subframe component directory (e.g. ${DEFAULT_SUBFRAME_TS_ALIAS})`,
-      validate: (value) => {
-        return typeof value === "string" && value.endsWith(TS_ALIAS_SUFFIX)
-          ? true
-          : `Alias must end with '${TS_ALIAS_SUFFIX}' so that it matches all files in the directory`
+    const componentsDirAlias = await ask<string>(
+      {
+        type: "text",
+        name: "componentsDirAlias",
+        initial: `${DEFAULT_SUBFRAME_TS_ALIAS}${TS_ALIAS_SUFFIX}`,
+        message: `Configure an alias for the subframe component directory (e.g. ${DEFAULT_SUBFRAME_TS_ALIAS})`,
+        validate: (value) => {
+          return typeof value === "string" && value.endsWith(TS_ALIAS_SUFFIX)
+            ? true
+            : `Alias must end with '${TS_ALIAS_SUFFIX}' so that it matches all files in the directory`
+        },
       },
-      onState: abortOnState,
-    })
+      {
+        override: initOptions.alias,
+        requiredHint: `Pass ${COMMAND_ALIAS_KEY} <alias> to set the import alias.`,
+      },
+    )
 
-    if (response.componentsDirAlias && config.directory) {
-      config.importAlias = response.componentsDirAlias
+    if (componentsDirAlias && config.directory) {
+      config.importAlias = componentsDirAlias
 
       const aliases = {
         /** just the one alias for now */
         // NOTE: tsconfig.json requires relative paths (unless baseUrl is set), and posixJoin strips the ./
-        [response.componentsDirAlias]: ["./" + posixJoin(config.directory, TS_ALIAS_SUFFIX)],
+        [componentsDirAlias]: ["./" + posixJoin(config.directory, TS_ALIAS_SUFFIX)],
       }
 
       if (await exists(tsConfigPath)) {

--- a/packages/subframe-cli/src/sync.ts
+++ b/packages/subframe-cli/src/sync.ts
@@ -3,18 +3,21 @@ import { join } from "node:path"
 import {
   COMMAND_ALL_KEY,
   COMMAND_ALL_KEY_SHORT,
+  COMMAND_AUTH_TOKEN_KEY,
+  COMMAND_AUTH_TOKEN_KEY_SHORT,
   COMMAND_INSTALL_KEY,
   COMMAND_INSTALL_KEY_SHORT,
+  COMMAND_NO_INSTALL_KEY,
   COMMAND_PROJECT_ID_KEY,
   COMMAND_PROJECT_ID_KEY_SHORT,
 } from "shared/constants"
 import { TruncatedProjectId } from "shared/types"
-import { getAccessToken } from "./access-token"
+import { resolveAccessToken } from "./access-token"
 import { cwd } from "./common"
 import { localSyncSettings } from "./common"
 import { MALFORMED_INIT_MESSAGE, SUBFRAME_SYNC_MESSAGE, WRONG_PROJECT_MESSAGE } from "./constants"
 import { installDependencies } from "./install-dependencies"
-import { makeCLILogger } from "./logger/logger-cli"
+import { runCommand } from "./run-command"
 import { syncComponents } from "./sync-components"
 import { TS_ALIAS_SUFFIX, updateSyncSettings } from "./sync-settings"
 
@@ -24,24 +27,25 @@ export const syncCommand = new Command()
   .argument("[components...]", "the components to sync")
   .option(`${COMMAND_ALL_KEY_SHORT}, ${COMMAND_ALL_KEY}`, "sync all components")
   .option(`${COMMAND_PROJECT_ID_KEY_SHORT}, ${COMMAND_PROJECT_ID_KEY} <projectId>`, "project id to run sync with")
+  .option(`${COMMAND_AUTH_TOKEN_KEY_SHORT}, ${COMMAND_AUTH_TOKEN_KEY} <auth-token>`, "auth token to use")
   .option(`${COMMAND_INSTALL_KEY_SHORT}, ${COMMAND_INSTALL_KEY}`, "install dependencies after syncing")
-  .action(async (components, opts) => {
-    const cliLogger = makeCLILogger()
-
-    try {
+  .option(COMMAND_NO_INSTALL_KEY, "skip installing dependencies after syncing")
+  .action(async (components, opts) =>
+    runCommand("sync", async (cliLogger) => {
       if (localSyncSettings?.projectId && opts.projectId && localSyncSettings.projectId !== opts.projectId) {
         await cliLogger.trackWarningAndFlush("[CLI]: sync project id mismatch")
-        console.error(WRONG_PROJECT_MESSAGE)
-        process.exit(1)
+        throw new Error(WRONG_PROJECT_MESSAGE)
       }
 
       if (!localSyncSettings) {
         await cliLogger.trackWarningAndFlush("[CLI]: sync could not find local sync settings")
-        console.error(MALFORMED_INIT_MESSAGE)
-        process.exit(1)
+        throw new Error(MALFORMED_INIT_MESSAGE)
       }
 
-      const tokenWithTeam = await getAccessToken(cliLogger, { teamId: localSyncSettings?.teamId })
+      const tokenWithTeam = await resolveAccessToken(cliLogger, {
+        authTokenFlag: opts.authToken,
+        teamId: localSyncSettings?.teamId,
+      })
 
       const accessToken = tokenWithTeam.token
 
@@ -70,11 +74,15 @@ export const syncCommand = new Command()
         cssType: localSyncSettings.cssType ?? "tailwind",
       })
 
-      await installDependencies({ cwd, didCreateNewProject: false }, opts)
+      const { didInstall } = await installDependencies({ cwd, didCreateNewProject: false }, opts)
 
       console.timeEnd(SUBFRAME_SYNC_MESSAGE)
-    } catch (err: any) {
-      console.error(err)
-      await cliLogger.trackWarningAndFlush("[CLI]: sync uncaught error", { error: err.toString() })
-    }
-  })
+
+      return {
+        projectId,
+        components: components.length ? components : "all",
+        directory: localSyncSettings.directory,
+        didInstall,
+      }
+    }),
+  )

--- a/packages/subframe-cli/test/e2e/auth.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/auth.e2e.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { makeHome, makeProjectDir, PROJECT_SETTINGS, runCli, scaffoldProject, setupMockServer,TOKEN } from "./harness"
+
+const getMock = setupMockServer()
+
+async function initedProject() {
+  const dir = makeProjectDir()
+  await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+  return dir
+}
+
+describe("authentication", () => {
+  it("authenticates with the --auth-token flag (no env var)", async () => {
+    const dir = await initedProject()
+
+    const result = await runCli(["sync", "--all", "--auth-token", TOKEN, "--no-install", "--json"], { cwd: dir })
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.find((c) => c.path === "/api/cli/verify")?.auth).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it("authenticates with the SUBFRAME_AUTH_TOKEN env var", async () => {
+    const dir = await initedProject()
+
+    const result = await runCli(["sync", "--all", "--no-install", "--json"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/verify")).toBe(true)
+  })
+
+  it("reuses a cached token without re-verifying on the next command", async () => {
+    const dir = await initedProject()
+    const home = makeHome()
+
+    // First run verifies and caches the token.
+    const first = await runCli(["sync", "--all", "--no-install"], { cwd: dir, token: TOKEN, home })
+    expect(first.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/verify")).toBe(true)
+
+    getMock().reset()
+
+    // Second run (same home) should hit the cache and skip the verify round-trip.
+    const second = await runCli(["sync", "--all", "--no-install"], { cwd: dir, token: TOKEN, home })
+    expect(second.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/verify")).toBe(false)
+  })
+
+  it("fails (without hanging) when the token is rejected", async () => {
+    const dir = await initedProject()
+    getMock().routes["GET /api/cli/verify"] = () => ({ status: 401, json: { message: "Invalid token" } })
+
+    const result = await runCli(["sync", "--all"], { cwd: dir, token: "bad-token" })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/authenticate|invalid/i)
+  })
+})

--- a/packages/subframe-cli/test/e2e/flags.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/flags.e2e.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, PROJECT_SETTINGS, runCli, scaffoldProject, setupMockServer, TOKEN } from "./harness"
+
+const getMock = setupMockServer()
+
+async function syncProject() {
+  const dir = makeProjectDir()
+  await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+  return dir
+}
+
+async function initProject() {
+  const dir = makeProjectDir()
+  await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+  return dir
+}
+
+describe("flag interactions", () => {
+  it("--auth-token takes precedence over the SUBFRAME_AUTH_TOKEN env var", async () => {
+    const dir = await syncProject()
+
+    const result = await runCli(["sync", "--all", "--auth-token", "flag-token", "--no-install", "--json"], {
+      cwd: dir,
+      token: "env-token", // would be used only if the flag didn't win
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.find((c) => c.path === "/api/cli/verify")?.auth).toBe("Bearer flag-token")
+  })
+
+  it("--non-interactive (strict) fails where --yes (lenient) accepts defaults — same args", async () => {
+    const base = ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--json"]
+
+    // Strict: the unspecified sync/install/tailwind steps must be given explicitly.
+    const strict = await runCli([...base, "--non-interactive"], { cwd: await initProject(), token: TOKEN })
+    expect(strict.exitCode).toBe(1)
+    expect((strict.json() as { error: string }).error).toMatch(/--sync|--install|--tailwind/)
+
+    getMock().reset()
+
+    // Lenient: the same command accepts the safe defaults and completes.
+    const lenient = await runCli([...base, "--yes"], { cwd: await initProject(), token: TOKEN })
+    expect(lenient.exitCode).toBe(0)
+  })
+
+  it("the later of --sync / --no-sync wins (negatable flag precedence)", async () => {
+    const base = ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--no-install", "--no-update-import-alias", "--json"]
+
+    const noSyncWins = await runCli([...base, "--sync", "--no-sync"], { cwd: await initProject(), token: TOKEN })
+    expect(noSyncWins.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/sync")).toBe(false)
+
+    getMock().reset()
+
+    const syncWins = await runCli([...base, "--no-sync", "--sync"], { cwd: await initProject(), token: TOKEN })
+    expect(syncWins.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/sync")).toBe(true)
+  })
+
+  it("strict mode also governs the install step (not only init's prompts)", async () => {
+    const dir = makeProjectDir()
+    // No @subframe/core => installDependencies has work to do => the confirm fires.
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"], coreVersion: null })
+
+    const result = await runCli(["sync", "--all", "--non-interactive", "--json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect((result.json() as { error: string }).error).toMatch(/--install/)
+  })
+
+  it("strict mode succeeds once every value is supplied explicitly", async () => {
+    const dir = await initProject()
+
+    const result = await runCli(
+      [
+        "init",
+        "--non-interactive",
+        "--projectId",
+        "proj_1",
+        "--dir",
+        "./src",
+        "--alias",
+        "@/ui/*",
+        "--no-install",
+        "--no-sync",
+        "--no-tailwind",
+        "--no-update-import-alias",
+        "--json",
+      ],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ ok: true, command: "init" })
+  })
+
+  it("--json implies non-interactive: a missing value fails with an envelope, never a prompt", async () => {
+    const dir = await initProject()
+    getMock().routes["GET /api/cli/list-projects"] = () => ({
+      json: {
+        projects: [
+          { truncatedProjectId: "proj_1", name: "Alpha" },
+          { truncatedProjectId: "proj_2", name: "Beta" },
+        ],
+      },
+    })
+
+    // No --projectId and multiple projects: would prompt interactively, but --json must not.
+    const result = await runCli(["init", "--dir", "./src", "--alias", "@/ui/*", "--no-install", "--no-sync", "--json"], {
+      cwd: dir,
+      token: TOKEN,
+    })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.json()).toMatchObject({ ok: false })
+  })
+})

--- a/packages/subframe-cli/test/e2e/global.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/global.e2e.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, runCli } from "./harness"
+
+// These don't touch the backend, so no mock server is needed.
+
+describe("global behavior", () => {
+  it("--version prints the version and exits 0", async () => {
+    const result = await runCli(["--version"], { cwd: makeProjectDir() })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
+  })
+
+  it("--help lists the commands", async () => {
+    const result = await runCli(["--help"], { cwd: makeProjectDir() })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatch(/init/)
+    expect(result.stdout).toMatch(/sync/)
+    expect(result.stdout).toMatch(/push-component/)
+    expect(result.stdout).toMatch(/import/)
+  })
+
+  it("surfaces the non-interactive flags in help", async () => {
+    const result = await runCli(["--help"], { cwd: makeProjectDir() })
+
+    expect(result.stdout).toMatch(/--yes/)
+    expect(result.stdout).toMatch(/--non-interactive/)
+    expect(result.stdout).toMatch(/--json/)
+  })
+
+  it("shows the negatable flags in init --help", async () => {
+    const result = await runCli(["init", "--help"], { cwd: makeProjectDir() })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatch(/--no-install/)
+    expect(result.stdout).toMatch(/--no-sync/)
+    expect(result.stdout).toMatch(/--no-tailwind/)
+  })
+
+  it("exits non-zero on an unknown command", async () => {
+    const result = await runCli(["frobnicate"], { cwd: makeProjectDir() })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).not.toBe(0)
+  })
+})

--- a/packages/subframe-cli/test/e2e/harness.ts
+++ b/packages/subframe-cli/test/e2e/harness.ts
@@ -1,0 +1,190 @@
+import { execa } from "execa"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { mkdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { afterAll, afterEach, beforeAll } from "vitest"
+import { MockServer, startMockServer } from "./mock-server"
+
+// Base URL of the mock server for the current test file, set by setupMockServer
+// and consumed by runCli (via SUBFRAME_BASE_URL). Lets each file use an ephemeral
+// port instead of a hardcoded one, so the suite never collides with a real dev
+// server on 6501.
+let activeBaseUrl: string | undefined
+
+/** Token the mock backend accepts by default (see mock-server defaultRoutes). */
+export const TOKEN = "test-token"
+
+/** A typical .subframe/sync.json for an already-initialized project. */
+export const PROJECT_SETTINGS = {
+  projectId: "proj_1",
+  directory: "./src",
+  importAlias: "@/ui/*",
+  teamId: 1,
+  cssType: "tailwind",
+}
+
+// The real CLI entrypoint (the published bin), so we exercise argv parsing,
+// TTY detection, process.exit codes, and stdout/stderr exactly as a user would.
+const CLI_BIN = resolve(__dirname, "../../bin/main-sync.js")
+
+/**
+ * A fake `curl` placed first on PATH so `getLatestPackageVersion` (which shells
+ * out to `curl https://registry.npmjs.org/...`) resolves offline and the suite
+ * stays hermetic. It always reports version 1.0.0.
+ */
+let fakeBinDir: string | undefined
+function fakeCurlDir(): string {
+  if (!fakeBinDir) {
+    fakeBinDir = mkdtempSync(join(tmpdir(), "subframe-cli-bin-"))
+    const curlPath = join(fakeBinDir, "curl")
+    writeFileSync(curlPath, `#!/bin/sh\necho '{"version":"1.0.0"}'\n`, { mode: 0o755 })
+  }
+  return fakeBinDir
+}
+
+export interface CliResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  /** Parsed stdout when --json was used (throws if stdout isn't valid JSON). */
+  json(): unknown
+  timedOut: boolean
+  /** The isolated HOME the run used (pass it back via RunOptions.home to reuse the token cache). */
+  home: string
+}
+
+export interface RunOptions {
+  cwd: string
+  /** Value for SUBFRAME_AUTH_TOKEN; omit to simulate having no credentials. */
+  token?: string
+  /** Reuse a specific HOME (e.g. to test the cached-token path across two runs). */
+  home?: string
+  /** Extra env vars. */
+  env?: Record<string, string>
+}
+
+/**
+ * Register a mock server for the current test file (shared across its tests,
+ * reset between them) on an ephemeral port. runCli points the CLI at it via
+ * SUBFRAME_BASE_URL.
+ */
+export function setupMockServer(): () => MockServer {
+  let mock: MockServer
+  beforeAll(async () => {
+    mock = await startMockServer()
+    activeBaseUrl = `http://127.0.0.1:${mock.port}`
+  })
+  afterAll(async () => {
+    await mock.close()
+    activeBaseUrl = undefined
+  })
+  afterEach(() => {
+    mock.reset()
+  })
+  return () => mock
+}
+
+/** A fresh isolated HOME directory. */
+export function makeHome(): string {
+  return mkdtempSync(join(tmpdir(), "subframe-cli-home-"))
+}
+
+/**
+ * Run the CLI as a subprocess (always against the --dev backend at
+ * localhost:6501) with an isolated home dir, a non-TTY stdin, and a hard
+ * timeout so a regression that reintroduces a blocking prompt fails loudly
+ * instead of hanging the suite.
+ */
+export async function runCli(args: string[], options: RunOptions): Promise<CliResult> {
+  const home = options.home ?? makeHome()
+
+  const env: Record<string, string> = {
+    HOME: home,
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    // eslint-disable-next-line turbo/no-undeclared-env-vars -- test helper, not a turbo-cached input
+    PATH: `${fakeCurlDir()}:${process.env.PATH ?? ""}`,
+    // Make sure nothing routes our localhost calls through a proxy.
+    HTTP_PROXY: "",
+    HTTPS_PROXY: "",
+    NO_PROXY: "*",
+    // Point the CLI at this file's mock server (ephemeral port), overriding --dev's
+    // hardcoded localhost:6501 so we never collide with a real dev server.
+    ...(activeBaseUrl ? { SUBFRAME_BASE_URL: activeBaseUrl } : {}),
+    ...(options.token ? { SUBFRAME_AUTH_TOKEN: options.token } : {}),
+    ...options.env,
+  }
+
+  const result = await execa("node", [CLI_BIN, ...args, "--dev"], {
+    cwd: options.cwd,
+    env,
+    extendEnv: true,
+    reject: false,
+    stdin: "ignore", // non-TTY: prompts must not block
+    timeout: 20_000,
+  })
+
+  return {
+    exitCode: result.exitCode ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    timedOut: result.timedOut === true,
+    home,
+    json() {
+      return JSON.parse(result.stdout)
+    },
+  }
+}
+
+/** Write a file (creating parent dirs) relative to `dir`. */
+export async function writeProjectFile(dir: string, relativePath: string, contents: string): Promise<string> {
+  const abs = join(dir, relativePath)
+  await mkdir(dirname(abs), { recursive: true })
+  await writeFile(abs, contents)
+  return abs
+}
+
+/** Create a temp project directory and return its absolute path. */
+export function makeProjectDir(): string {
+  return mkdtempSync(join(tmpdir(), "subframe-cli-proj-"))
+}
+
+export interface ScaffoldOptions {
+  /** Dependencies to list in package.json (e.g. tailwindcss, @subframe/core). */
+  dependencies?: Record<string, string>
+  /**
+   * Version to pin @subframe/core at. Defaults to a very high version so the
+   * dependency check finds nothing to install. Pass `null` to omit it entirely
+   * (so the install step actually has work to do, e.g. to exercise that prompt).
+   */
+  coreVersion?: string | null
+  /** When set, writes .subframe/sync.json with these settings. */
+  syncSettings?: Record<string, unknown>
+  /** Subdirectories to create (e.g. ["src"]). */
+  dirs?: string[]
+}
+
+/** Write a minimal project (package.json + optional .subframe/sync.json) into `dir`. */
+export async function scaffoldProject(dir: string, options: ScaffoldOptions = {}): Promise<void> {
+  const coreVersion = options.coreVersion === undefined ? "999.0.0" : options.coreVersion
+  // @subframe/core at a high version + the fake curl reporting 1.0.0 means
+  // installDependencies finds nothing to install and never shells out.
+  const dependencies = {
+    ...(coreVersion === null ? {} : { "@subframe/core": coreVersion }),
+    ...options.dependencies,
+  }
+
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "test-project", version: "0.0.0", dependencies }, null, 2),
+  )
+
+  for (const sub of options.dirs ?? []) {
+    await mkdir(join(dir, sub), { recursive: true })
+  }
+
+  if (options.syncSettings) {
+    await mkdir(join(dir, ".subframe"), { recursive: true })
+    await writeFile(join(dir, ".subframe", "sync.json"), JSON.stringify(options.syncSettings, null, 2))
+  }
+}

--- a/packages/subframe-cli/test/e2e/import.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/import.e2e.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, runCli, scaffoldProject, setupMockServer, TOKEN, writeProjectFile } from "./harness"
+
+const getMock = setupMockServer()
+
+const VALID_MANIFEST = {
+  theme: [],
+  components: [{ name: "Button", entrypoint: "Button.tsx", sourceFiles: ["Button.tsx"], supportingFiles: [] }],
+}
+
+describe("import", () => {
+  it("uploads a design system and starts the import", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "Button.tsx", "export const Button = () => null\n")
+    await writeProjectFile(dir, "manifest.json", JSON.stringify(VALID_MANIFEST))
+
+    const result = await runCli(["import", "-p", "proj_1", "-m", "manifest.json", "--json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ ok: true, command: "import", sessionId: "session_1" })
+    const paths = getMock().calls.map((c) => `${c.method} ${c.path}`)
+    expect(paths).toContain("POST /api/cli/import/create-session")
+    expect(paths).toContain("PUT /mock-s3-upload")
+    expect(paths).toContain("POST /api/cli/import/start")
+  })
+
+  it("fails on malformed manifest JSON", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "manifest.json", "this is not json")
+
+    const result = await runCli(["import", "-p", "proj_1", "-m", "manifest.json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/parse manifest/i)
+  })
+
+  it("fails on an invalid manifest shape", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    // entrypoint not listed in sourceFiles
+    await writeProjectFile(
+      dir,
+      "manifest.json",
+      JSON.stringify({ theme: [], components: [{ name: "Button", entrypoint: "Button.tsx", sourceFiles: [], supportingFiles: [] }] }),
+    )
+
+    const result = await runCli(["import", "-p", "proj_1", "-m", "manifest.json"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(1)
+  })
+
+  it("fails when the manifest file doesn't exist", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+
+    const result = await runCli(["import", "-p", "proj_1", "-m", "missing.json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+  })
+
+  it("errors when required options are missing", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+
+    const result = await runCli(["import", "-p", "proj_1"], { cwd: dir, token: TOKEN }) // no --manifest
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/manifest/i)
+  })
+})

--- a/packages/subframe-cli/test/e2e/init.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/init.e2e.test.ts
@@ -1,0 +1,235 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, runCli, scaffoldProject, setupMockServer, TOKEN, writeProjectFile } from "./harness"
+
+const getMock = setupMockServer()
+
+// Common flags for a hermetic existing-project init (no network beyond the mock).
+const SAFE = ["--no-install", "--no-sync", "--no-update-import-alias", "--json"]
+
+describe("init (existing project)", () => {
+  it("initializes a Tailwind v3 project end-to-end", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", ...SAFE],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ ok: true, command: "init", cssType: "tailwind", didCreateNewProject: false })
+    // sync settings + the generated theme style file are written.
+    expect(existsSync(join(dir, ".subframe", "sync.json"))).toBe(true)
+    expect(existsSync(join(dir, "src", "ui-styles.css"))).toBe(true)
+  })
+
+  it("detects the Tailwind version from package.json (no --css-type needed)", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", ...SAFE], {
+      cwd: dir,
+      token: TOKEN,
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ cssType: "tailwind" })
+  })
+
+  it("injects the theme import into the global CSS for Tailwind v4", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^4.0.0" }, dirs: ["src"] })
+    await writeProjectFile(dir, "src/index.css", '@import "tailwindcss";\n')
+
+    const result = await runCli(
+      [
+        "init",
+        "--projectId",
+        "proj_1",
+        "--css-type",
+        "tailwind-v4",
+        "--dir",
+        "./src",
+        "--alias",
+        "@/ui/*",
+        "--css-path",
+        "./src/index.css",
+        ...SAFE,
+      ],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ cssType: "tailwind-v4" })
+    expect(readFileSync(join(dir, "src", "index.css"), "utf8")).toMatch(/theme\.css/)
+  })
+
+  it("configures an existing tailwind.config.js when --tailwind is set", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+    await writeProjectFile(dir, "tailwind.config.js", "module.exports = { content: [], theme: { extend: {} } }\n")
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--tailwind", ...SAFE],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(readFileSync(join(dir, "tailwind.config.js"), "utf8")).toMatch(/presets/)
+  })
+
+  it("--no-tailwind leaves an existing tailwind.config.js untouched", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+    const original = "module.exports = { content: [], theme: { extend: {} } }\n"
+    await writeProjectFile(dir, "tailwind.config.js", original)
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--no-tailwind", ...SAFE],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(readFileSync(join(dir, "tailwind.config.js"), "utf8")).toBe(original)
+  })
+})
+
+describe("init (project selection)", () => {
+  it("auto-selects when the account has a single project", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(["init", "--dir", "./src", "--alias", "@/ui/*", ...SAFE], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/list-projects")).toBe(true)
+  })
+
+  it("fails (instead of guessing) when there are multiple projects and no --projectId", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+    getMock().routes["GET /api/cli/list-projects"] = () => ({
+      json: {
+        projects: [
+          { truncatedProjectId: "proj_1", name: "Alpha" },
+          { truncatedProjectId: "proj_2", name: "Beta" },
+        ],
+      },
+    })
+
+    const result = await runCli(["init", "--dir", "./src", "--alias", "@/ui/*", ...SAFE], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(1)
+    expect((result.json() as { error: string }).error).toMatch(/multiple|projectId/i)
+  })
+
+  it("skips listing projects when --projectId is supplied", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", ...SAFE], {
+      cwd: dir,
+      token: TOKEN,
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/list-projects")).toBe(false)
+  })
+})
+
+describe("init (import alias update)", () => {
+  const initWithOldAlias = () => ({
+    json: {
+      styleFile: { fileType: "css", fileName: "ui-styles.css", directory: "", metadata: {}, contents: "/* */" },
+      cssType: "tailwind",
+      oldImportAlias: "@/old",
+      projectInfo: { teamId: 1, truncatedProjectId: "proj_1", name: "Test Project" },
+    },
+  })
+
+  it("updates the import alias when --update-import-alias is set", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+    getMock().routes["POST /api/cli/init"] = initWithOldAlias
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--update-import-alias", "--no-install", "--no-sync", "--json"],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    const aliasCall = getMock().calls.find((c) => c.path === "/api/cli/import-alias")
+    expect(aliasCall).toBeDefined()
+    expect((aliasCall?.body as { importAlias: string }).importAlias).toBe("@/ui")
+  })
+
+  it("leaves the import alias alone with --no-update-import-alias", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+    getMock().routes["POST /api/cli/init"] = initWithOldAlias
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--no-update-import-alias", "--no-install", "--no-sync", "--json"],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/import-alias")).toBe(false)
+  })
+})
+
+describe("init (sync step)", () => {
+  it("--no-sync skips the initial component sync", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--no-sync", "--no-install", "--no-update-import-alias", "--json"],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/sync")).toBe(false)
+  })
+
+  it("--sync runs the initial component sync", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--dir", "./src", "--alias", "@/ui/*", "--sync", "--no-install", "--no-update-import-alias", "--json"],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(getMock().calls.some((c) => c.path === "/api/cli/sync")).toBe(true)
+  })
+})
+
+describe("init (validation & strict mode)", () => {
+  it("rejects a malformed --alias (missing /*) instead of writing a broken config", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { dependencies: { tailwindcss: "^3.4.0" }, dirs: ["src"] })
+
+    const result = await runCli(
+      ["init", "--projectId", "proj_1", "--alias", "@/ui", "--dir", "./src", ...SAFE],
+      { cwd: dir, token: TOKEN },
+    )
+
+    expect(result.exitCode).toBe(1)
+    expect((result.json() as { error?: string }).error ?? "").toMatch(/alias/i)
+  })
+
+  it("strict mode fails fast naming the missing flag instead of prompting", async () => {
+    const dir = makeProjectDir() // no package.json => new-project flow
+
+    const result = await runCli(["init", "--non-interactive", "--template", "vite", "--name", "foo"], { cwd: dir })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/--css-type/)
+  })
+})

--- a/packages/subframe-cli/test/e2e/mock-server.ts
+++ b/packages/subframe-cli/test/e2e/mock-server.ts
@@ -1,0 +1,139 @@
+import { createServer, Server } from "node:http"
+
+/**
+ * A tiny mock of the Subframe CLI backend (`/api/cli/*`). The CLI points at it
+ * via `--dev` (which sets BASE_URL to http://localhost:6501).
+ *
+ * Tests can inspect `calls` to assert which requests were made, and override any
+ * route via `routes["POST /api/cli/sync"] = (body) => ({ status, json })` to
+ * simulate errors or alternate responses.
+ */
+export interface RecordedCall {
+  method: string
+  path: string
+  body: unknown
+  auth?: string
+}
+
+type RouteHandler = (body: unknown) => { status?: number; json: unknown }
+
+export interface MockServer {
+  server: Server
+  port: number
+  calls: RecordedCall[]
+  routes: Record<string, RouteHandler>
+  reset(): void
+  close(): Promise<void>
+}
+
+function codeFile(fileName: string, contents: string) {
+  return {
+    fileType: fileName.endsWith(".css") ? "css" : "tsx",
+    fileName,
+    directory: "",
+    metadata: {},
+    contents,
+  }
+}
+
+const PROJECT_INFO = { teamId: 1, truncatedProjectId: "proj_1", name: "Test Project" }
+
+// Sensible defaults that let a normal init/sync flow succeed.
+// Built once the server's actual (ephemeral) port is known, so the import flow's
+// presigned upload URL points back at this same server (mock S3).
+function makeDefaultRoutes(baseUrl: string): Record<string, RouteHandler> {
+  return {
+    "GET /api/cli/verify": () => ({ json: { success: true, userId: "user_1", teamId: 1 } }),
+    "GET /api/cli/list-projects": () => ({
+      json: { projects: [{ truncatedProjectId: "proj_1", name: "Test Project" }] },
+    }),
+    "POST /api/cli/init": () => ({
+      json: {
+        styleFile: codeFile("ui-styles.css", "/* subframe styles */\n"),
+        cssType: "tailwind",
+        oldImportAlias: "@/ui",
+        projectInfo: PROJECT_INFO,
+      },
+    }),
+    "POST /api/cli/sync": () => ({
+      json: {
+        definitionFiles: [],
+        otherFiles: [codeFile("Button.tsx", "export const Button = () => null\n")],
+        missingComponents: [],
+        projectInfo: PROJECT_INFO,
+      },
+    }),
+    "POST /api/cli/import-alias": () => ({ json: { success: true } }),
+    "POST /api/cli/push-component": (body) => ({
+      json: { success: true, componentName: (body as { componentName?: string })?.componentName ?? "Component" },
+    }),
+    "POST /api/cli/import/create-session": () => ({
+      json: { sessionId: "session_1", presignedUrl: `${baseUrl}/mock-s3-upload` },
+    }),
+    "PUT /mock-s3-upload": () => ({ json: {} }),
+    "POST /api/cli/import/start": () => ({ json: { success: true } }),
+  }
+}
+
+// Defaults to an ephemeral port (0 → the OS assigns a free one) so the suite
+// never collides with a real dev server (e.g. a local backend on 6501).
+export async function startMockServer(port = 0): Promise<MockServer> {
+  const calls: RecordedCall[] = []
+  const routes: Record<string, RouteHandler> = {}
+  // Assigned once the server is listening and its base URL is known.
+  let defaults: Record<string, RouteHandler> = {}
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on("data", (c) => chunks.push(c as Buffer))
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8")
+      let body: unknown
+      try {
+        body = raw ? JSON.parse(raw) : undefined
+      } catch {
+        body = raw
+      }
+
+      const path = (req.url ?? "").split("?")[0]
+      const key = `${req.method} ${path}`
+      calls.push({ method: req.method ?? "", path, body, auth: req.headers.authorization })
+
+      const handler = routes[key] ?? defaults[key]
+      if (!handler) {
+        res.writeHead(404, { "Content-Type": "application/json" })
+        res.end(JSON.stringify({ message: `No mock route for ${key}` }))
+        return
+      }
+
+      const { status = 200, json } = handler(body)
+      res.writeHead(status, { "Content-Type": "application/json" })
+      res.end(JSON.stringify(json))
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port, "127.0.0.1", resolve)
+  })
+
+  const address = server.address()
+  const actualPort = typeof address === "object" && address ? address.port : port
+  defaults = makeDefaultRoutes(`http://127.0.0.1:${actualPort}`)
+
+  return {
+    server,
+    port: actualPort,
+    calls,
+    routes,
+    reset() {
+      calls.length = 0
+      for (const key of Object.keys(routes)) {
+        delete routes[key]
+      }
+    },
+    close() {
+      return new Promise<void>((resolve) => server.close(() => resolve()))
+    },
+  }
+}

--- a/packages/subframe-cli/test/e2e/push-component.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/push-component.e2e.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, runCli, scaffoldProject, setupMockServer, TOKEN, writeProjectFile } from "./harness"
+
+const getMock = setupMockServer()
+
+describe("push-component", () => {
+  it("pushes a component and reports the component name", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "Button.tsx", "export const Button = () => null\n")
+
+    const result = await runCli(["push-component", "Button.tsx", "-p", "proj_1", "--json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ ok: true, command: "push-component", componentName: "Button" })
+    const pushCall = getMock().calls.find((c) => c.path === "/api/cli/push-component")
+    expect((pushCall?.body as { componentName: string }).componentName).toBe("Button")
+  })
+
+  it("passes --skip-normalize through to the backend", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "Button.tsx", "export const Button = () => null\n")
+
+    const result = await runCli(["push-component", "Button.tsx", "-p", "proj_1", "--skip-normalize", "--json"], {
+      cwd: dir,
+      token: TOKEN,
+    })
+
+    expect(result.exitCode).toBe(0)
+    const pushCall = getMock().calls.find((c) => c.path === "/api/cli/push-component")
+    expect((pushCall?.body as { skipNormalize?: boolean }).skipNormalize).toBe(true)
+  })
+
+  it("fails when the file has no exported component", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "not-a-component.ts", "const x = 1\n")
+
+    const result = await runCli(["push-component", "not-a-component.ts", "-p", "proj_1"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/component name/i)
+  })
+
+  it("fails when the component file doesn't exist", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+
+    const result = await runCli(["push-component", "missing.tsx", "-p", "proj_1"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+  })
+
+  it("errors when the required --project-id is missing", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir)
+    await writeProjectFile(dir, "Button.tsx", "export const Button = () => null\n")
+
+    const result = await runCli(["push-component", "Button.tsx"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/project-id/i)
+  })
+})

--- a/packages/subframe-cli/test/e2e/sync.e2e.test.ts
+++ b/packages/subframe-cli/test/e2e/sync.e2e.test.ts
@@ -1,0 +1,127 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { makeProjectDir, PROJECT_SETTINGS, runCli, scaffoldProject, setupMockServer,TOKEN } from "./harness"
+
+const getMock = setupMockServer()
+
+describe("sync", () => {
+  it("syncs all components, writes files, and prints a JSON result", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, {
+      dependencies: { tailwindcss: "^3.4.0" },
+      syncSettings: PROJECT_SETTINGS,
+      dirs: ["src"],
+    })
+
+    const result = await runCli(["sync", "--all", "--json", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(result.json()).toMatchObject({ ok: true, command: "sync", projectId: "proj_1", components: "all" })
+    expect(existsSync(join(dir, "src", "Button.tsx"))).toBe(true)
+    expect(getMock().calls.find((c) => c.path === "/api/cli/verify")?.auth).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it("syncs only the named components", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+
+    const result = await runCli(["sync", "Button", "Card", "--json", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    const syncCall = getMock().calls.find((c) => c.path === "/api/cli/sync")
+    expect((syncCall?.body as { components: string[] }).components).toEqual(["Button", "Card"])
+    expect(result.json()).toMatchObject({ command: "sync", components: ["Button", "Card"] })
+  })
+
+  it("fails fast with a JSON error envelope when the project isn't initialized", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir) // no .subframe/sync.json
+
+    const result = await runCli(["sync", "--json"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.json()).toMatchObject({ ok: false, command: "sync" })
+    expect((result.json() as { error: string }).error).toMatch(/init/i)
+  })
+
+  it("refuses to sync when --projectId disagrees with sync.json", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+
+    const result = await runCli(["sync", "--all", "--projectId", "proj_other", "--no-install"], {
+      cwd: dir,
+      token: TOKEN,
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/project/i)
+  })
+
+  it("never hangs waiting for credentials in a non-TTY (exits with guidance)", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+
+    const result = await runCli(["sync", "--all"], { cwd: dir }) // no token, empty home
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/credentials|auth-token|SUBFRAME_AUTH_TOKEN/i)
+  })
+
+  it("returns a non-zero code (not 0) when the backend rejects the sync", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+    getMock().routes["POST /api/cli/sync"] = () => ({ status: 500, json: { message: "Internal error" } })
+
+    const result = await runCli(["sync", "--all", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(1)
+  })
+
+  it("warns about components the backend couldn't find", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+    getMock().routes["POST /api/cli/sync"] = () => ({
+      json: {
+        definitionFiles: [],
+        otherFiles: [],
+        missingComponents: ["Nonexistent"],
+        projectInfo: { teamId: 1, truncatedProjectId: "proj_1", name: "Test Project" },
+      },
+    })
+
+    const result = await runCli(["sync", "Nonexistent", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    // The "not found" warning is human chatter (console.log → stdout in non-json mode).
+    expect(result.stdout).toMatch(/Nonexistent/)
+  })
+
+  it("backfills a missing teamId into sync.json (legacy migration)", async () => {
+    const dir = makeProjectDir()
+    const { teamId, ...withoutTeamId } = PROJECT_SETTINGS
+    void teamId
+    await scaffoldProject(dir, { syncSettings: withoutTeamId, dirs: ["src"] })
+
+    const result = await runCli(["sync", "--all", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    const written = JSON.parse(readFileSync(join(dir, ".subframe", "sync.json"), "utf8"))
+    expect(written.teamId).toBe(1)
+  })
+
+  it("--json keeps stdout to just the result (chatter goes to stderr)", async () => {
+    const dir = makeProjectDir()
+    await scaffoldProject(dir, { syncSettings: PROJECT_SETTINGS, dirs: ["src"] })
+
+    const result = await runCli(["sync", "--all", "--json", "--no-install"], { cwd: dir, token: TOKEN })
+
+    expect(result.exitCode).toBe(0)
+    // stdout parses cleanly as the single result object — no chatter mixed in.
+    expect(result.json()).toMatchObject({ ok: true, command: "sync" })
+  })
+})

--- a/packages/subframe-cli/vitest.config.ts
+++ b/packages/subframe-cli/vitest.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig } from "vitest/config"
+import { configDefaults, defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
     clearMocks: true,
+    // The e2e suite has its own config (vitest.e2e.config.ts) and is run via
+    // `npm run test:e2e`; keep it out of the fast unit run.
+    exclude: [...configDefaults.exclude, "test/e2e/**"],
   },
 })

--- a/packages/subframe-cli/vitest.e2e.config.ts
+++ b/packages/subframe-cli/vitest.e2e.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config"
+
+// End-to-end suite: spawns the built CLI against a mock backend. Run with
+// `npm run test:e2e` (which builds the bundle first). Kept separate from the
+// fast unit suite and serialized because the tests share one mock server port.
+export default defineConfig({
+  test: {
+    include: ["test/e2e/**/*.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+  },
+})

--- a/plugins/claude/subframe/.claude-plugin/plugin.json
+++ b/plugins/claude/subframe/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "subframe",
   "description": "Design and build UIs with Subframe. Create pixel-perfect React + Tailwind pages using your design system, explore design variations, and implement with business logic.",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "author": {
     "name": "Subframe"
   },

--- a/plugins/claude/subframe/skills/install/SKILL.md
+++ b/plugins/claude/subframe/skills/install/SKILL.md
@@ -86,10 +86,11 @@ Prompt the user to choose:
 
 ### 2. Run CLI Init
 
-This command must be run outside of a sandbox, so it can correctly setup all the necessary files. Pass all arguments directly to avoid interactive prompts:
+This command must be run outside of a sandbox, so it can correctly setup all the necessary files. Pass all arguments directly so the CLI doesn't prompt. `--yes` accepts safe defaults for anything not specified:
 
 ```bash
 npx @subframe/cli@latest init \
+  --yes \
   --name {PROJECT_NAME} \
   --auth-token {TOKEN} \
   -p {PROJECT_ID} \
@@ -113,7 +114,7 @@ Where:
   - Next.js: `src/app/globals.css`
   - Astro: `src/styles/global.css`
 
-**Important**: All arguments must be passed explicitly to avoid interactive prompts, which can cause the CLI to exit silently when run non-interactively.
+**Important**: Pass arguments explicitly so the CLI never needs to prompt. When run non-interactively (no TTY, or with `--yes`), it uses your flags and safe defaults; if a required value is genuinely missing it exits non-zero with a message naming the flag to pass (rather than hanging or exiting silently).
 
 The CLI will:
 
@@ -159,10 +160,11 @@ If any are missing, let the user know before proceeding.
 
 ### 3. Run CLI Init
 
-This command must be run outside of a sandbox, so it can correctly setup all the necessary files. Pass all arguments directly to avoid interactive prompts:
+This command must be run outside of a sandbox, so it can correctly setup all the necessary files. Pass all arguments directly so the CLI doesn't prompt. `--yes` accepts safe defaults for anything not specified:
 
 ```bash
 npx @subframe/cli@latest init \
+  --yes \
   --auth-token {TOKEN} \
   -p {PROJECT_ID} \
   --dir ./src/ui \
@@ -171,7 +173,7 @@ npx @subframe/cli@latest init \
   --sync
 ```
 
-**Important**: All arguments must be passed explicitly to avoid interactive prompts, which can cause the CLI to exit silently when run non-interactively.
+**Important**: Pass arguments explicitly so the CLI never needs to prompt. When run non-interactively (no TTY, or with `--yes`), it uses your flags and safe defaults; if a required value is genuinely missing it exits non-zero with a message naming the flag to pass (rather than hanging or exiting silently).
 
 The CLI will attempt to:
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["SUBFRAME_BASE_URL", "SUBFRAME_AUTH_TOKEN"],
   "tasks": {
     "build": {
       "env": ["NODE_ENV", "SEGMENT_WRITE_KEY"],


### PR DESCRIPTION
The CLI relied on interactive prompts that hang when stdin isn't a TTY (CI, agents, piped invocations) and exited 0 on failure. This adds a real non-interactive mode and fixes the flags so every prompt can be supplied or skipped from the command line.

Core:
- ask() wrapper routes all prompts; in non-interactive mode it uses the flag value or a safe default, validating/formatting it the same way an interactive answer would be, or fails fast naming the missing flag.
- Auto-detect non-TTY; -y/--yes accept defaults; --non-interactive is a strict mode (never assume a default); --json imply non-interactive.
- runCommand() wrapper: one clean error line (never a stack), non-zero exit on failure, and a { ok, command, ... } / { ok: false, error } JSON envelope with --json. Telemetry flush can't mask the real error.

Flags:
- Negatable --no-install/--no-sync/--no-tailwind and --update-import-alias so steps can be forced on or off without a prompt.
- --auth-token on sync and push-component; SUBFRAME_AUTH_TOKEN env var (preferred for CI); cached tokens are reused without re-verifying.
- A flag-provided --alias is validated up front (it bypasses the prompt), so a malformed alias fails instead of writing a broken config.
- Centralized global-flag parsing in flags.ts.

Tests:
- End-to-end suite (npm run test:e2e) spawns the real binary as a non-TTY subprocess against a mock backend, fully hermetic and with a hard timeout so a reintroduced blocking prompt fails loudly. Covers every command plus auth and flag interactions (precedence, strict vs lenient, negatable last-wins).
- Unit tests for the ask() wrapper.

Docs: new "CLI in CI & agents" guide.