### PR TITLE
Document AI variation review for quick edits

### DIFF
--- a/packages/docs/learn/ask-ai/making-quick-edits.mdx
+++ b/packages/docs/learn/ask-ai/making-quick-edits.mdx
@@ -46,3 +46,17 @@ Open the [quick insert](/learn/design-mode/adding-elements) <Icon icon="plus" si
 4. Press **Ask AI to insert...**
 
 AI adds the new element next to your selection, automatically applying layout and wrapping stacks for you.
+
+## Reviewing variations
+
+For open-ended prompts, AI generates up to three distinct variations so you can compare directions before committing. Deterministic edits—like "make the text bold" or "change the button to blue"—return a single result.
+
+A review tray appears with a labeled thumbnail for each variation:
+
+{/* TODO: Add screenshot of the variation review tray */}
+
+1. Click a variation to preview it live on the canvas
+2. Type in the shared input to **Refine...** and regenerate the set (optional)
+3. Click **Keep** to apply the active variation, or **Discard** to dismiss
+
+When editing an existing element, the tray also includes an **Original** card so you can compare against the unedited version.


### PR DESCRIPTION
Adds a "Reviewing variations" section to the Quick edits doc covering the variation review tray, refining the set, and keeping or discarding a variation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPGaYDkfhHWhBy9GmAZrq3)_