### PR TITLE
Update editor navigation and flow preview docs

### DIFF
--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -19,7 +19,7 @@ We recommend [importing your theme](/learn/theme/importing-tokens) first so that
 
 <Tabs>
   <Tab title="From code">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
 
     2. Click **New component**
 
@@ -96,7 +96,7 @@ export { Button, buttonVariants }
 
   </Tab>
   <Tab title="From Figma">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
     
     2. Click **New component**
     
@@ -108,14 +108,14 @@ export { Button, buttonVariants }
 
 ## Creating components using AI
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Describe the component you want in the prompt
 4. Press <kbd>Enter</kbd> or click the send button — the AI agent will take a few minutes to create your component
 
 ## Creating components from scratch
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Choose one of:
    - Remix an existing prebuilt component
@@ -146,7 +146,7 @@ Subframe AI will auto-suggest properties using best practices based on what you 
 
 To edit a component:
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click on the component
 3. Click **Edit component**
 
@@ -225,7 +225,7 @@ For more information, see [syncing components](/concepts/syncing-components).
 
 Copy components and pages from one of your other Subframe projects into the current one. Each selection brings along the dependencies it needs to render — nested components, theme tokens, fonts, custom icons, and image assets.
 
-1. Navigate to **Components** in the navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **Import from...** (top right) and select **Another project**
 3. Pick the source project from the dropdown
 4. Browse or search the source project's components and pages — click any item to preview it on the right

--- a/packages/docs/learn/design-mode/preview.mdx
+++ b/packages/docs/learn/design-mode/preview.mdx
@@ -5,4 +5,4 @@ description: Preview your designs and test interactions.
 
 Preview mode shows how your design behaves outside the editor. Interactions like hover states work in preview.
 
-To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar, or press <kbd>Shift</kbd> + <kbd>Space</kbd>. From the flow editor, the same shortcut previews the flow starting from its first page.
+To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar, or press <kbd>Shift</kbd> + <kbd>Space</kbd>. From the flow editor, the same shortcut previews the flow starting from the selected page, or from the flow's first page when no page is selected.

--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -7,8 +7,8 @@ Flows are folders for grouping related pages together. Flows are the set of page
 
 ## Creating a flow
 
-1. Navigate to **Pages** in navbar
-2. Click **New flow** in the bottom of the left sidebar
+1. In the **Pages** section of the left sidebar, click the **+** button
+2. Select **New flow**
 
 ## Renaming a flow
 


### PR DESCRIPTION
Updates docs to match the current editor:

- Components are reached via the **Design System** section in the left sidebar (not the navbar)
- Creating a flow uses the **+** menu in the **Pages** sidebar
- Flow preview starts from the selected page when one is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111Xp3kbnoBjyfXnozfkSuY

---
_Generated by [Claude Code](https://claude.ai/code/session_0111Xp3kbnoBjyfXnozfkSuY)_