### PR TITLE
Docs: update editor navigation for the unified Design System sidebar

### DIFF
--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -19,7 +19,7 @@ We recommend [importing your theme](/learn/theme/importing-tokens) first so that
 
 <Tabs>
   <Tab title="From code">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
 
     2. Click **New component**
 
@@ -96,7 +96,7 @@ export { Button, buttonVariants }
 
   </Tab>
   <Tab title="From Figma">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
     
     2. Click **New component**
     
@@ -108,14 +108,14 @@ export { Button, buttonVariants }
 
 ## Creating components using AI
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Describe the component you want in the prompt
 4. Press <kbd>Enter</kbd> or click the send button — the AI agent will take a few minutes to create your component
 
 ## Creating components from scratch
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Choose one of:
    - Remix an existing prebuilt component
@@ -146,7 +146,7 @@ Subframe AI will auto-suggest properties using best practices based on what you 
 
 To edit a component:
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click on the component
 3. Click **Edit component**
 
@@ -225,7 +225,7 @@ For more information, see [syncing components](/concepts/syncing-components).
 
 Copy components and pages from one of your other Subframe projects into the current one. Each selection brings along the dependencies it needs to render — nested components, theme tokens, fonts, custom icons, and image assets.
 
-1. Navigate to **Components** in the navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **Import from...** (top right) and select **Another project**
 3. Pick the source project from the dropdown
 4. Browse or search the source project's components and pages — click any item to preview it on the right

--- a/packages/docs/learn/projects/project-settings.mdx
+++ b/packages/docs/learn/projects/project-settings.mdx
@@ -11,10 +11,10 @@ description: Configure project settings like code generation and AI preferences.
     alt="Project settings showing the project settings dialog"
   />
 </Frame>
+{/* TODO: Update screenshot — project settings now opens from the gear icon next to Design System in the left sidebar */}
 
-1. Open [Subframe](https://app.subframe.com)
-2. Click the project switcher in the top nav
-3. Select **Project settings**
+1. Open a project in [Subframe](https://app.subframe.com)
+2. In the left sidebar, click the **settings** <Icon icon="settings" size={16} /> icon next to **Design System**
 
 You should see the project settings dialog.
 

--- a/packages/docs/learn/snippets/snippets.mdx
+++ b/packages/docs/learn/snippets/snippets.mdx
@@ -29,4 +29,4 @@ See [adding elements](/learn/design-mode/adding-elements) for more info.
 
 ## Managing snippets
 
-Access your snippets at any time from **[Snippets](https://app.subframe.com/library?component=snippets)** in the left panel. You can edit or delete snippets from here.
+Access your snippets at any time from **[Snippets](https://app.subframe.com/library?component=snippets)** under **Design System** in the left sidebar. You can edit or delete snippets from here.


### PR DESCRIPTION
Updates navigation references across the docs to match the unified editor, where Components, Snippets, and Theme now live under a **Design System** section in the left sidebar.

- **Components** (`learn/components/overview.mdx`): open under **Design System** in the left sidebar (was "navbar")
- **Snippets** (`learn/snippets/snippets.mdx`): managed under **Design System** in the left sidebar
- **Project settings** (`learn/projects/project-settings.mdx`): open from the settings gear next to **Design System**; flagged the entrypoint screenshot for an update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcGbhyLKp9B9gyTYUyrLoS)_