### PR TITLE
Document list sorting and project search

### DIFF
--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -199,6 +199,14 @@ You can reset a prebuilt component to its original state, reverting any customiz
 
 This restores the component to its default configuration from the Subframe library.
 
+## Sorting components
+
+The **Components** page lists every component in your project along with when each was last edited. Use the sort control at the top of the list to change the order:
+
+- **A-Z** — Alphabetical by name (default)
+- **Recently edited** — Most recently edited first
+- **Recently created** — Most recently created first
+
 ## Component docs
 
 <Frame>

--- a/packages/docs/learn/pages/pages.mdx
+++ b/packages/docs/learn/pages/pages.mdx
@@ -30,6 +30,15 @@ Double-click a page name in the pages sidebar or on the flow editor canvas to re
 1. Right-click a page or click <Icon icon="ellipsis" size={16} />
 2. Select **Duplicate**
 
+## Sorting pages
+
+Use the sort control at the top of the **Pages** view to change how pages are ordered:
+
+- **Grouped by flow** — Pages organized under their [flows](/learn/flows/flows) (default)
+- **Recently edited** — Most recently edited first
+- **Recently created** — Most recently created first
+- **A-Z** — Alphabetical by name
+
 ## FAQ
 
 <AccordionGroup>

--- a/packages/docs/learn/projects/overview.mdx
+++ b/packages/docs/learn/projects/overview.mdx
@@ -22,6 +22,10 @@ Each project has its own theme, components, and pages. All team members can acce
 
 Click the project switcher in the top-left to see all projects. Type to search if you have many.
 
+## Manage all projects
+
+Go to **Settings \> Projects** to see every project in one place. Search by name or sort by most recent or alphabetically to find a project quickly.
+
 ## Rename a project
 
 1. Go to **Settings \> Projects** or click **Manage projects** in the project switcher

--- a/packages/docs/learn/snippets/snippets.mdx
+++ b/packages/docs/learn/snippets/snippets.mdx
@@ -30,3 +30,5 @@ See [adding elements](/learn/design-mode/adding-elements) for more info.
 ## Managing snippets
 
 Access your snippets at any time from **[Snippets](https://app.subframe.com/library?component=snippets)** in the left panel. You can edit or delete snippets from here.
+
+Use the sort control at the top of the list to order snippets by **A-Z** (default), **Recently edited**, or **Recently created**.


### PR DESCRIPTION
Documents the sort controls for the Pages, Components, and Snippets lists, and project search/sort on the Settings > Projects page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgHKKZrNAPk6kMe3pzcSds)_