### PR TITLE
Update navigation paths for editor sidebar and Projects page

### DIFF
--- a/packages/docs/guides/component-docs.mdx
+++ b/packages/docs/guides/component-docs.mdx
@@ -7,7 +7,7 @@ description: Find documentation for Subframe components and their underlying lib
 
 Each component in your design system has documentation for its React props, source code, and interactive examples.
 
-1. Open Subframe and click the **Components** tab in the top nav
+1. Open your project and select **Components** under **Design System** in the left sidebar
 2. Click on the component you want
 3. View the props, source code, and examples
 

--- a/packages/docs/guides/dark-mode.mdx
+++ b/packages/docs/guides/dark-mode.mdx
@@ -9,7 +9,7 @@ Subframe has built-in dark mode support. Enable it in your theme to define light
 
 ## Enable dark mode
 
-1. Open **Theme** in the top navigation
+1. Open **Theme** under **Design System** in the left sidebar
 2. At the top of the theme page, click **Add dark mode**
 3. Each token now shows light and dark values — edit the dark values to define your dark palette
 4. Preview your components and pages in both light and dark mode using the sun/moon toggle in the editor toolbar

--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -19,7 +19,7 @@ We recommend [importing your theme](/learn/theme/importing-tokens) first so that
 
 <Tabs>
   <Tab title="From code">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
 
     2. Click **New component**
 
@@ -96,7 +96,7 @@ export { Button, buttonVariants }
 
   </Tab>
   <Tab title="From Figma">
-    1. Navigate to **Components** in navbar
+    1. Open **Components** under **Design System** in the left sidebar
     
     2. Click **New component**
     
@@ -108,14 +108,14 @@ export { Button, buttonVariants }
 
 ## Creating components using AI
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Describe the component you want in the prompt
 4. Press <kbd>Enter</kbd> or click the send button — the AI agent will take a few minutes to create your component
 
 ## Creating components from scratch
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **New component**
 3. Choose one of:
    - Remix an existing prebuilt component
@@ -146,7 +146,7 @@ Subframe AI will auto-suggest properties using best practices based on what you 
 
 To edit a component:
 
-1. Navigate to **Components** in navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click on the component
 3. Click **Edit component**
 
@@ -233,7 +233,7 @@ For more information, see [syncing components](/concepts/syncing-components).
 
 Copy components and pages from one of your other Subframe projects into the current one. Each selection brings along the dependencies it needs to render — nested components, theme tokens, fonts, custom icons, and image assets.
 
-1. Navigate to **Components** in the navbar
+1. Open **Components** under **Design System** in the left sidebar
 2. Click **Import from...** (top right) and select **Another project**
 3. Pick the source project from the dropdown
 4. Browse or search the source project's components and pages — click any item to preview it on the right

--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -7,8 +7,8 @@ Flows are folders for grouping related pages together. Flows are the set of page
 
 ## Creating a flow
 
-1. Navigate to **Pages** in navbar
-2. Click **New flow** in the bottom of the left sidebar
+1. Open the **Pages** section in the left sidebar
+2. Click **New flow** at the bottom of the left sidebar
 
 ## Renaming a flow
 

--- a/packages/docs/learn/projects/overview.mdx
+++ b/packages/docs/learn/projects/overview.mdx
@@ -7,8 +7,8 @@ Each project has its own theme, components, and pages. All team members can acce
 
 ## Create a project
 
-1. Click the project switcher in the top nav
-2. Click **New project...**
+1. Open the **Projects** page — click your avatar in the top right and select **Projects**
+2. Click **New project**
 3. Enter a name
 4. Choose how to start:
    - **New project** — A clean slate with no theme or components. Best for importing your designs.
@@ -20,25 +20,25 @@ Each project has its own theme, components, and pages. All team members can acce
 
 ## Switching projects
 
-Click the project switcher in the top-left to see all projects. Type to search if you have many.
+Open the **Projects** page to see all projects, then click a project to open it. Type to search if you have many.
 
 ## Manage all projects
 
-Go to **Settings \> Projects** to see every project in one place. Search by name or sort by most recent or alphabetically to find a project quickly.
+Open the **Projects** page to see every project in one place. Search by name or sort by most recent or alphabetically to find a project quickly.
 
 ## Rename a project
 
-1. Go to **Settings \> Projects** or click **Manage projects** in the project switcher
+1. Open the **Projects** page
 2. Hover over the project and click <Icon icon="pencil" size={16} />
 3. Enter the new name and click **Save**
 
 ## Duplicate a project
 
-Hover over a project in **Settings \> Projects** and click <Icon icon="copy" size={16} />. This creates a new project with the same components, theme, and pages.
+Hover over a project on the **Projects** page and click <Icon icon="copy" size={16} />. This creates a new project with the same components, theme, and pages.
 
 ## Delete a project
 
-Hover over a project in **Settings \> Projects** and click <Icon icon="trash" size={16} />.
+Hover over a project on the **Projects** page and click <Icon icon="trash" size={16} />.
 
 <Warning>Deleting is permanent. All pages, components, and theme data are erased.</Warning>
 

--- a/packages/docs/learn/projects/overview.mdx
+++ b/packages/docs/learn/projects/overview.mdx
@@ -7,7 +7,7 @@ Each project has its own theme, components, and pages. All team members can acce
 
 ## Create a project
 
-1. Open the **Projects** page — click your avatar in the top right and select **Projects**
+1. Open the **Projects** page — click the Subframe logo in the top left
 2. Click **New project**
 3. Enter a name
 4. Choose how to start:

--- a/packages/docs/learn/projects/project-settings.mdx
+++ b/packages/docs/learn/projects/project-settings.mdx
@@ -8,13 +8,15 @@ description: Configure project settings like code generation and AI preferences.
 <Frame>
   <img
     src="/images/projects/project-settings-entrypoint.png"
-    alt="Project settings showing the project settings dialog"
+    alt="The Design System section in the left sidebar with the Project settings gear icon highlighted"
   />
 </Frame>
 
-1. Open [Subframe](https://app.subframe.com)
-2. Click the project switcher in the top nav
-3. Select **Project settings**
+{/* TODO: Update image — project settings now opens from the Design System section, not the top-nav project switcher */}
+
+1. Open your project in the editor
+2. In the left sidebar, find the **Design System** section
+3. Click the **Settings** <Icon icon="settings" size={16} /> icon next to **Design System**
 
 You should see the project settings dialog.
 

--- a/packages/docs/learn/projects/version-history.mdx
+++ b/packages/docs/learn/projects/version-history.mdx
@@ -11,8 +11,8 @@ You can restore previous versions at the project-level, or for individual pages,
 
 Use project-level version history when you need to roll back multiple changes at once.
 
-1. Click the project switcher in the top left navigation
-2. Select **Show version history**
+1. Click the **project menu** <Icon icon="chevron-down" size={16} /> next to the Subframe logo
+2. Select **Version history**
 3. Select the version timestamp from the dropdown in the banner at the top
 4. Click **Restore** to revert to that version.
 


### PR DESCRIPTION
Component, theme, and project-settings navigation now lives in the editor left sidebar (Design System section) and the Projects page rather than the top navigation. This updates docs that still referenced the old top-nav paths:

- **`learn/components/overview.mdx`** — "Navigate to **Components** in navbar" → open **Components** under **Design System** in the left sidebar (6 occurrences)
- **`guides/component-docs.mdx`** — "Components tab in the top nav" → Design System sidebar
- **`guides/dark-mode.mdx`** — "Open **Theme** in the top navigation" → under **Design System** in the left sidebar
- **`learn/flows/flows.mdx`** — "Navigate to **Pages** in navbar" → **Pages** section in the left sidebar
- **`learn/projects/project-settings.mdx`** — project settings dialog now opens from the **Settings** gear on the **Design System** section header (added a screenshot TODO)
- **`learn/projects/overview.mdx`** — "Settings > Projects" / "project switcher" / "Manage projects" → the **Projects** page (opened from the avatar menu)
- **`learn/projects/version-history.mdx`** — project version history now opens from the **project menu** next to the logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6pcYwzYptgcGSs2Adekhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6pcYwzYptgcGSs2Adekhp)_