### PR TITLE
Docs: clarify flow editor preview shortcut targets the selected page

### DIFF
--- a/packages/docs/learn/design-mode/preview.mdx
+++ b/packages/docs/learn/design-mode/preview.mdx
@@ -5,4 +5,4 @@ description: Preview your designs and test interactions.
 
 Preview mode shows how your design behaves outside the editor. Interactions like hover states work in preview.
 
-To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar, or press <kbd>Shift</kbd> + <kbd>Space</kbd>. From the flow editor, the same shortcut previews the flow starting from its first page.
+To preview your design, click the **eye** icon <Icon icon="eye" size={16} /> in the navbar, or press <kbd>Shift</kbd> + <kbd>Space</kbd>. From the flow editor, the same shortcut previews the selected page, or the flow's first page when nothing is selected.


### PR DESCRIPTION
Updates `learn/design-mode/preview.mdx` to reflect that the preview keyboard shortcut (Shift+Space) in the flow editor previews the currently selected page, falling back to the flow's first page when nothing is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vizctf5YjaP3MFaWuzz8TZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vizctf5YjaP3MFaWuzz8TZ)_