### PR TITLE
Fix pages sort label to match UI (Group by flow)

### DIFF
--- a/packages/docs/learn/pages/pages.mdx
+++ b/packages/docs/learn/pages/pages.mdx
@@ -34,7 +34,7 @@ Double-click a page name in the pages sidebar or on the flow editor canvas to re
 
 Use the sort control at the top of the **Pages** view to change how pages are ordered:
 
-- **Grouped by flow** — Pages organized under their [flows](/learn/flows/flows) (default)
+- **Group by flow** — Pages organized under their [flows](/learn/flows/flows) (default)
 - **Recently edited** — Most recently edited first
 - **Recently created** — Most recently created first
 - **A-Z** — Alphabetical by name


### PR DESCRIPTION
Updates the pages sort documentation to match the current UI label. The sort option is now labeled **Group by flow** in the app; the doc still said "Grouped by flow".