### PR TITLE
Fix color token creation steps to match Theme UI

### DIFF
--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -56,7 +56,7 @@ To quickly add tokens from an existing design system, see [Importing tokens](/le
 
 **New color token:**
 
-1. Click **New color** in any folder, or click the **+** button at the end of a folder's token row
+1. Click **New color** in the **Colors** section header, click a folder's **...** menu and select **New color token**, or click the **+** button at the end of a folder's token row
 2. Name your token descriptively: `accent-primary`, `surface-elevated`
 3. Set color via picker or reference existing token
 


### PR DESCRIPTION
Updates the "New color token" steps in the Theme docs to match the current in-app labels and menu placement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKG7fJWmaHRYs4iQDAPo4C)_