### PR TITLE
Document duplicating a flow

### DIFF
--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -21,6 +21,13 @@ Double-click a flow name in the pages sidebar to rename it. Press <kbd>Enter</kb
 
 You can also drag pages directly into a flow from the pages list when editing a page.
 
+## Duplicating a flow
+
+1. Click <Icon icon="ellipsis" size={16} /> on a flow in the pages sidebar
+2. Select **Duplicate**
+
+Duplicating a flow copies all of its pages along with the flow's [prototype](/learn/prototype-mode/overview).
+
 ## FAQ
 
 <AccordionGroup>


### PR DESCRIPTION
Adds a "Duplicating a flow" section to the Flows doc, covering the flow actions menu Duplicate option and noting that it copies the flow's pages along with its prototype.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSW2DP1wUdouRt6twFrFjd)_