### PR TITLE
Fix Sync project steps to reference the project menu

### DIFF
--- a/packages/docs/learn/projects/overview.mdx
+++ b/packages/docs/learn/projects/overview.mdx
@@ -51,8 +51,8 @@ Hover over a project on the **Projects** page and click <Icon icon="trash" size=
 
 If you maintain a separate design system project:
 
-1. Open the project switcher
-2. Click **Sync project...**
+1. Click the **project menu** <Icon icon="chevron-down" size={16} /> next to the Subframe logo
+2. Select **Sync project...**
 3. Follow the prompts to merge updates
 
 ## Transfer a project to another team


### PR DESCRIPTION
Updates the "Sync design system across projects" steps to open the project menu next to the Subframe logo, matching the current UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WkMfQTkDN8wqk4sQxNR13)_