### PR TITLE
Update skills and docs for new design tool capabilities

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -6,7 +6,7 @@ description: Let AI coding assistants directly access and edit your Subframe des
 import McpSkillsInstall from "/snippets/mcp-skills-install.mdx"
 import CopyMcpLink from "/snippets/copy-mcp-link.mdx"
 
-The Subframe MCP server gives AI coding assistants like Claude Code, Cursor, and Codex direct access to your Subframe projects. AI can read, design, and delete pages, components, and snippets, read prototypes, write design documents, and edit the theme.
+The Subframe MCP server gives AI coding assistants like Claude Code, Cursor, and Codex direct access to your Subframe projects. AI can read, design, and delete pages, components, and snippets, screenshot pages, read prototypes, write design documents, edit the theme, and search the Subframe docs.
 
 A separate Subframe Docs MCP server gives AI access to Subframe documentation (this site).
 
@@ -31,6 +31,7 @@ The Subframe MCP server exposes tools across several categories. Most read tools
 | `list_projects` | Lists all projects you have access to | Array of `projectId`, `name`, `teamId`, `teamName` |
 | `generate_auth_token` | Generates a CLI auth token for a team | `authToken` |
 | `get_project_info` | Project metadata plus all project-level design documents | `id`, `name`, `docs` (array of `id`, `title`, `contents`) |
+| `search_docs` | Searches the Subframe documentation (this site) for product and workflow questions | `results` (matching documentation content with titles and links) |
 
 ### Pages
 
@@ -38,8 +39,9 @@ The Subframe MCP server exposes tools across several categories. Most read tools
 | --- | --- | --- | --- |
 | `list_pages` | List all pages with the flow each belongs to | `projectId` | Array of `id`, `name`, `url`, `lastModifiedAt`, `flowId`, `flowName` |
 | `get_page_info` | Generated React/Tailwind code for a page. Pass `includeNodeIds: true` to get a `data-node-id` on every element for use with `edit_page` | `id`/`name`/`url`, `projectId`, `includeNodeIds?` | `id`, `name`, `lastModifiedAt`, `files` |
-| `design_page` | Generates 1-4 page variations as an asynchronous background job. Variations land as pages in a flow as they finish | `description`, `variations`, `flowName`, `projectId`, `codeContext?`, `additionalReferences?` | `flowId`, `flowUrl`, `jobId` |
+| `design_page` | Generates 1-4 page variations as an asynchronous background job. Variations land as pages in a flow as they finish | `description`, `variations`, `flowName`, `projectId`, `references?`, `sourcePageId?` | `flowId`, `flowUrl`, `jobId` |
 | `edit_page` | Apply a targeted edit to one node of an existing page — `replace` the node and its subtree, `insert-above`/`insert-below` a new sibling, or `delete` it. Call `get_page_info` with `includeNodeIds: true` first to get each element's `data-node-id`. Applied immediately | `id`/`name`/`url`, `nodeId`, `operation`, `code`, `projectId` | `pageUrl`, `appliedCode?`, `warnings?` |
+| `screenshot_page` | Renders a page and returns a screenshot so AI can check the result against the intended design. Use after `design_page`/`edit_page`, once background jobs finish | `id`/`name`/`url`, `projectId`, `darkMode?` | Screenshot image, `pageId`, `width`, `height` |
 | `delete_page` | Delete a page, removing it from its flow and stripping prototype actions referencing it. Refuses by default if referenced in other pages. Use `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
 
 ### Components
@@ -48,8 +50,8 @@ The Subframe MCP server exposes tools across several categories. Most read tools
 | --- | --- | --- | --- |
 | `list_components` | List all components | `projectId` | Array of `id`, `name`, `url`, `lastModifiedAt` |
 | `get_component_info` | Generated code plus attached design document | `id`/`name`/`url`, `projectId` | `id`, `name`, `lastModifiedAt`, `files`, `designDocuments` |
-| `design_component` | Designs a new component as an asynchronous background job | `description`, `name`, `projectId`, `additionalReferences?` | `componentId`, `componentUrl`, `jobId` |
-| `edit_component` | Edit an existing component as an asynchronous background job. Propagates to every page using the component | `id`/`name`/`url`, `description`, `projectId`, `additionalReferences?` | `componentUrl`, `jobId` |
+| `design_component` | Designs a new component as an asynchronous background job | `description`, `name`, `projectId`, `references?` | `componentId`, `componentUrl`, `jobId` |
+| `edit_component` | Edit an existing component as an asynchronous background job. Propagates to every page using the component | `id`/`name`/`url`, `description`, `projectId`, `references?` | `componentUrl`, `jobId` |
 | `delete_component` | Delete a component or custom page layout. Detachable components detach their instances; non-detachable ones delete instances; page layouts clear assignments. Some built-in components can't be deleted (`force` does not override). Refuses by default if in use — pass `force: true` to delete anyway | `id`/`name`/`url`, `projectId`, `force?` | `deletedId`, `deletedName`, `references` |
 
 ### Snippets
@@ -60,7 +62,7 @@ Snippets are small, standalone bits of UI typically embedded inside design docum
 | --- | --- | --- | --- |
 | `list_snippets` | List all snippets | `projectId` | Array of `id`, `name`, `url`, `lastModifiedAt` |
 | `get_snippet_info` | Generated code for a snippet. Pass `includeNodeIds: true` to get a `data-node-id` on every element for use with `edit_snippet` | `id`/`name`/`url`, `projectId`, `includeNodeIds?` | `id`, `name`, `lastModifiedAt`, `files` |
-| `design_snippet` | Design a new snippet | `description`, `name?`, `projectId`, `codeContext?`, `additionalReferences?` | `snippetId`, `snippetUrl` |
+| `design_snippet` | Design a new snippet | `description`, `name?`, `projectId`, `references?` | `snippetId`, `snippetUrl` |
 | `edit_snippet` | Apply a targeted edit to one node of an existing snippet (same model as `edit_page`). Call `get_snippet_info` with `includeNodeIds: true` first | `id`/`name`/`url`, `nodeId`, `operation`, `code`, `projectId` | `snippetUrl`, `appliedCode?`, `warnings?` |
 | `delete_snippet` | Delete a snippet. Any design document embeds are removed automatically | `id`/`name`/`url`, `projectId` | `deletedId`, `deletedName` |
 
@@ -100,6 +102,25 @@ Read existing docs first via `get_project_info` (project-level) or `get_componen
 | --- | --- | --- | --- |
 | `get_theme` | Generate the Tailwind theme for the project | `projectId`, `cssType?` | `theme` config |
 | `edit_theme` | Edits the project's visual theme (colors, fonts, corners, shadows, typography) from a natural-language prompt. Applies immediately to the whole project. Supports adding tokens, changing token values, renaming tokens, and **deleting tokens (destructive — references in designs are replaced with the token's concrete value at deletion time)**. | `description`, `projectId` | `themeUrl` |
+
+### Design references
+
+`design_page`, `design_component`, `edit_component`, and `design_snippet` accept an optional `references` array that grounds the generation in real material. Each entry pairs a `source` with a `usage` note telling the generator how to use that reference:
+
+```json
+{
+  "source": { "kind": "subframe", "id": "..." },
+  "usage": "Match this page's layout and header"
+}
+```
+
+| Source kind | Shape | Use for |
+| --- | --- | --- |
+| `subframe` | `{ "kind": "subframe", "id": "..." }` | An existing page, component, or snippet in the project, by ID or name. Resolved server-side — no need to inline its code |
+| `code` | `{ "kind": "code", "content": "..." }` | Raw code from your codebase: a surface to recreate, data types/interfaces, or usage patterns |
+| `image` | `{ "kind": "image", "url": "..." }` | A mockup or screenshot uploaded to Subframe. Only Subframe upload URLs work — external URLs are rejected — and up to 5 images are used per call |
+
+Invalid references are dropped with a warning in the tool result rather than failing the design.
 
 ### Async jobs
 

--- a/packages/docs/learn/ask-ai/image-to-design.mdx
+++ b/packages/docs/learn/ask-ai/image-to-design.mdx
@@ -1,9 +1,9 @@
 ---
 title: Image to design
-description: Upload images or paste URLs to prompt AI when generating designs.
+description: Upload images to prompt AI when generating designs.
 ---
 
-Upload screenshots, mockups, or paste website URLs and Ask AI will recreate designs using your components and theme.
+Upload screenshots or mockups and Ask AI will recreate designs using your components and theme.
 
 ## Upload an image
 
@@ -14,16 +14,6 @@ Upload screenshots, mockups, or paste website URLs and Ask AI will recreate desi
 AI analyzes the image and creates 1-4 variations that match the structure using your Subframe components.
 
 Supported formats: PNG, JPG, JPEG, WebP
-
-## Reference a URL
-
-Paste a public URL into the prompt area to use a live page as a reference. Ask AI loads the page, captures a screenshot, and reads the structure so generations can match both the visuals and the layout.
-
-1. Paste the URL into the Ask AI prompt
-2. Add a prompt — for example, "redesign this landing page with our theme" or "recreate the pricing section using our components"
-3. Press <kbd>Enter</kbd> to generate
-
-<Note>Only URLs you paste are fetched. Authenticated or private pages cannot be loaded.</Note>
 
 ## Import from Figma
 

--- a/packages/docs/learn/ask-ai/personalizing-ai.mdx
+++ b/packages/docs/learn/ask-ai/personalizing-ai.mdx
@@ -13,12 +13,12 @@ Add a system prompt about your project (e.g. company description, tone preferenc
   <img src="/images/ask-ai/personalizing-ai.png" alt="Personalizing AI showing the project settings dialog" />
 </Frame>
 
-1. Click the **gear icon** <Icon icon="settings" size={16} /> in the Ask AI chat bar
-2. Enter your **Company name**
-3. Enter your **project description** —describe your company, product, and design preferences
-4. Click **Save** to apply your settings
+{/* TODO: Update image — project context is now configured in project settings, not from the Ask AI chat bar */}
 
-Alternatively you can change this in your [project settings](/learn/projects/project-settings).
+1. Open [project settings](/learn/projects/project-settings)
+2. Enter your **Company name**
+3. Enter your **project description** — describe your company, product, and design preferences
+4. Click **Save** to apply your settings
 
 ## Referencing existing designs
 

--- a/packages/docs/learn/ask-ai/prompt-to-design.mdx
+++ b/packages/docs/learn/ask-ai/prompt-to-design.mdx
@@ -4,13 +4,16 @@ description: Use AI to generate page designs, make edits, and update your theme.
 ---
 
 <Frame>
-  <img src="/images/ask-ai/ask-ai-mode.png" alt="Ask AI mode showing the mode switcher and the prompt area" />
+  <img src="/images/ask-ai/ask-ai-mode.png" alt="The Ask AI panel docked to the right side of the editor" />
 </Frame>
+
+{/* TODO: Update image — Ask AI is now a docked panel toggled from the toolbar, not an editor mode */}
 
 You can prompt AI to generate page designs, edit your existing designs, or update your theme.
 
 - **Design new pages** — Generate multiple variations of page designs
 - **Edit your page directly** — Make targeted changes to your current page
+- **Design components and snippets** — Create reusable building blocks and design system examples
 - **Update your theme** — Modify colors, fonts, and tokens project-wide
 - **Answer questions** — Search Subframe docs for help with features and development workflows
 
@@ -18,57 +21,42 @@ Ask AI is for creating and updating designs. For adding interactivity and state,
 
 ## Getting started
 
-1. Click **Ask AI** in the mode switcher (top-right) of the page editor or press <kbd>Cmd</kbd> + <kbd>K</kbd> and select **Mode > Ask AI**
+1. Click the **Ask AI** button in the toolbar or press <kbd>Cmd</kbd> + <kbd>/</kbd>
 2. Type a prompt and press <kbd>Enter</kbd> or click the send button
 3. Ask AI will create a new conversation and responds to your prompt
 
-<video
-  autoPlay
-  muted
-  loop
-  playsInline
-  className="w-full"
-  src="https://hevpkratkeuc60w7.public.blob.vercel-storage.com/ask-ai-plus-drag-drop.mp4"
-/>
+The Ask AI panel docks to the right side of the editor and follows you across your project — it's available on all project level pages.
+
+{/* TODO: Add video of prompting in the docked Ask AI panel */}
 
 Our AI will choose how to respond based on your prompt:
 
 - **Variations** — For new designs, creative exploration, or prompts requiring new components. Ask AI will generate 1-4 variations for you to choose from.
 - **Direct edits** — For simple changes to existing elements like colors, text, or layout tweaks
 
-## Apply designs
+<Tip>You can keep prompting while AI is working — follow-up messages queue and send when the current response finishes. Click the stop button (or press <kbd>Esc</kbd>) to stop a running response.</Tip>
 
-After generations finish streaming, click each thumbnail to open a preview.
+## Review designs
 
-<Frame>
-  <img src="/images/ask-ai/apply-designs.png" alt="Ask AI variations showing the generated variations" />
-</Frame>
+Variations land as real pages in a flow on your canvas as each one finishes generating. The chat shows a live tile for each variation — click a tile to jump to that page on the canvas.
 
-From the preview, you can:
+{/* TODO: Add screenshot of variation tiles in the chat and applied pages in the flow */}
 
-- **Apply design** — Replace your current page
-- **Save as new page** — Create a new page with this design
-- **Ask follow-up** — Refine with another prompt
+From there you can:
 
-You can even **mix and match elements** from different variations by dragging elements from the preview onto your canvas.
-
-<video
-  autoPlay
-  muted
-  loop
-  playsInline
-  controls
-  className="w-full"
-  src="https://hevpkratkeuc60w7.public.blob.vercel-storage.com/Mintlify/ai-drag-to-insert-BKAcupQ453HXKXmsKaDGp6dw8cLmbW.mp4"
-/>
-
-After generating, send follow-up prompts or switch to [design mode](/learn/design-mode/layers) for manual edits. Each follow-up can reference the current page and previous generations.
+- **Ask a follow-up** — Refine a variation or combine ideas from different ones ("use the header from variation 1 with the layout from variation 3")
+- **Edit visually** — Open any variation in [design mode](/learn/design-mode/layers) for manual edits
+- **Delete** the variations you don't want
 
 ## Conversation history
 
-Recent conversations appear at the bottom of the Ask AI panel. Click **Show all history** to see older conversations grouped by date.
-
 Your conversations persist across sessions and pages so you can reference past generations.
+
+Click the history button at the top of the Ask AI panel to see every chat in the project, grouped by recency — or hover over it to peek at the list. An animated indicator means a chat is still working, and a dot marks unread results. Click the **+** button to start a new chat.
+
+Each chat is labeled with the page, component, or flow it last worked on. Click the label in the chat header to jump to that resource.
+
+{/* TODO: Add screenshot of the chat history menu in the Ask AI panel */}
 
 ## Ask AI toolbar
 
@@ -76,7 +64,6 @@ Ask AI includes additional tools:
 
 - **[Adding context with @](/learn/ask-ai/adding-context)** — Reference other pages, components, snippets, and docs in your prompt
 - **[Upload image](/learn/ask-ai/image-to-design)** — Add reference images
-- **[Reference a URL](/learn/ask-ai/image-to-design#reference-a-url)** — Paste a public URL to use a live page as a reference
 - **[Import from Figma](/learn/ask-ai/image-to-design#import-from-figma)** — Import Figma designs using the image model
 - **[Personalize AI](/learn/ask-ai/personalizing-ai)** — Configure project-wide context
 
@@ -90,7 +77,9 @@ Ask AI is great for generating new designs or making broad changes to your page.
 </Accordion>
 
 <Accordion title="How do I use AI with components?">
-  Open the component editor, then right-click or press <kbd>/</kbd> to open [quick actions](/learn/design-mode/quick-actions) and select **Ask AI to edit...**. You can insert elements, create variants, and refactor components directly in the component editor.
+  Open the component editor and use the same Ask AI panel to insert elements, create variants, and refactor components.
+  You can also right-click or press <kbd>/</kbd> to open [quick actions](/learn/design-mode/quick-actions) and select
+  **Ask AI to edit...**.
 </Accordion>
 
 <Accordion title="How do I undo changes?">

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -3,23 +3,22 @@ title: Overview
 description: Learn the Subframe editor interface and navigate between editing modes.
 ---
 
-The Subframe editor is where you design pages, build components, and export production-ready code. Switch between all four modes, depending on your task.
+The Subframe editor is where you design pages, build components, and export production-ready code. Switch between three modes depending on your task, and open Ask AI from any of them.
 
 ## Editor modes
 
 <Frame>
   <img
     src="/images/editor/editor-modes.png"
-    alt="Editor mode selector showing Ask AI, Design, Prototype, and Code mode buttons"
+    alt="Editor mode selector showing Design, Prototype, and Code mode buttons"
   />
 </Frame>
+
+{/* TODO: Update image — the mode switcher now shows Design, Prototype, and Code; Ask AI is a docked panel toggled from the toolbar */}
 
 You can use the mode buttons in the top-right of the editor to switch between the following modes:
 
 <CardGroup cols={2}>
-  <Card title="Ask AI" icon="sparkle">
-    Generate new pages and variations from text prompts or images.
-  </Card>
   <Card title="Design Mode" icon="square-mouse-pointer">
     Edit visually with drag-and-drop, responsive canvas, and layers & properties.
   </Card>
@@ -30,6 +29,8 @@ You can use the mode buttons in the top-right of the editor to switch between th
     View code, set up MCP server, and export to AI coding tools like Claude Code, Cursor, and Codex.
   </Card>
 </CardGroup>
+
+[Ask AI](/learn/ask-ai/prompt-to-design) is available in every mode — click the **Ask AI** button in the toolbar or press <kbd>Cmd</kbd> + <kbd>/</kbd> to open the docked panel and generate pages, components, and theme changes from a prompt.
 
 ## Editor layout
 
@@ -63,7 +64,7 @@ For example, in design mode, you'll see layout, sizing, colors, backgrounds, bor
 
 ### Show and hide panels
 
-Press <kbd>Cmd</kbd> + <kbd>\\</kbd> to cycle through panel layouts: both panels visible, left panel collapsed, then both panels hidden. Press <kbd>Cmd</kbd> + <kbd>.</kbd> to show or hide all panels at once.
+Press <kbd>Cmd</kbd> + <kbd>\\</kbd> to cycle through panel layouts: both panels visible, left panel collapsed, then both panels hidden. Press <kbd>Cmd</kbd> + <kbd>.</kbd> to show or hide all panels at once, including the Ask AI panel.
 
 ## Responsive breakpoints
 

--- a/packages/docs/learn/guides/working-with-ai-agents.mdx
+++ b/packages/docs/learn/guides/working-with-ai-agents.mdx
@@ -52,7 +52,7 @@ There are two ways to mix and match elements from different variations:
 
 Click any page on the flow canvas to enter the full design editor. From there you can:
 
-- Chat for edits in [Ask AI](/learn/ask-ai) mode
+- Chat for edits in the [Ask AI](/learn/ask-ai) panel
 - Drag-and-drop in [Design mode](/learn/design-mode)
 
 ## Using designs with your AI agent

--- a/packages/docs/learn/quickstart.mdx
+++ b/packages/docs/learn/quickstart.mdx
@@ -22,15 +22,16 @@ You can create a new page with AI or start from scratch.
 
     <img src="/images/quickstart/quickstart-prompt-ai.png" alt="Design with AI prompt dialog" />
 
+    {/* TODO: Update image — Ask AI is now a docked panel toggled from the toolbar */}
+
     Ask AI generates multiple design variations using your theme and components.
 
-    1. Open your project and switch to **Ask AI** mode.
+    1. Open your project and click the **Ask AI** button in the toolbar (or press <kbd>Cmd</kbd> + <kbd>/</kbd>).
     2. Type a prompt for the page you want to design.
-    3. Submit your prompt to open the page editor and wait for designs to generate.
-    4. Select a variation to preview in the Ask AI panel.
-    5. Click **Apply design** to add it to the current page.
+    3. Submit your prompt and wait for designs to generate.
+    4. Variations land as pages in a flow on your canvas — click a variation tile in the chat to open one.
 
-    <Tip>Mix and match elements from different variations by dragging to the page from the preview.</Tip>
+    <Tip>Ask a follow-up prompt to refine a variation or combine ideas from different ones.</Tip>
 
   </Step>
 

--- a/plugins/claude/subframe/.claude-plugin/plugin.json
+++ b/plugins/claude/subframe/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "subframe",
   "description": "Design and build UIs with Subframe. Create pixel-perfect React + Tailwind pages using your design system, explore design variations, and implement with business logic.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "author": {
     "name": "Subframe"
   },

--- a/plugins/claude/subframe/skills/bulk-import/SKILL.md
+++ b/plugins/claude/subframe/skills/bulk-import/SKILL.md
@@ -37,12 +37,14 @@ The project ID is also visible in any Subframe URL: `app.subframe.com/<PROJECT_I
 We only want **visual/presentational layer** files — the reusable UI primitives that make up the design system. Skip anything that's deeply coupled to business logic, data models, API calls, or application state.
 
 **Include:**
+
 - Pure UI components (buttons, inputs, cards, modals, badges, etc.)
 - Layout primitives (containers, grids, stacks, etc.)
 - Theme/styling files
 - Stories
 
 **Exclude:**
+
 - Components that fetch data, call APIs, or manage application state
 - Page-level components that wire together business logic
 - Utility functions, hooks, or helpers that aren't visual
@@ -51,16 +53,19 @@ We only want **visual/presentational layer** files — the reusable UI primitive
 Use Glob and Read tools to find files. Look for:
 
 **Theme files** (global styling):
+
 - `tailwind.config.*`
 - Global CSS files (e.g. `globals.css`, `global.css`, `app.css`, `index.css`)
 - Design token files (e.g. `tokens.json`, `tokens.ts`, `theme.ts`)
 
 **Component files**:
+
 - React component files (`.tsx`, `.jsx`) in component directories
 - Story files (`.stories.tsx`, `.stories.jsx`, `.stories.ts`)
 - Component CSS modules
 
 Use these search strategies:
+
 1. Look for `tailwind.config.*` at the project root
 2. Look for global CSS in `src/styles/`, `src/`, `app/`, `styles/`
 3. Look for components in common directories: `src/components/`, `components/`, `src/ui/`, `ui/`, `lib/components/`
@@ -74,9 +79,11 @@ For each component, separate files into two categories:
 **`entrypoint`** — the path to the main component file. Must reference one of the `sourceFiles`.
 
 **`sourceFiles`** — the primary component implementation:
+
 - The component source file(s) (`.tsx`, `.jsx`) containing markup and styles
 
 **`supportingFiles`** — everything else that helps understand the component:
+
 - Story files (`.stories.tsx`, `.stories.jsx`, `.stories.ts`)
 - CSS modules (`.module.css`, `.module.scss`)
 - Documentation files (`.md`)
@@ -95,21 +102,13 @@ Write the manifest to `.subframe/import-design-system.json`:
 
 ```json
 {
-  "theme": [
-    "tailwind.config.ts",
-    "src/styles/globals.css"
-  ],
+  "theme": ["tailwind.config.ts", "src/styles/globals.css"],
   "components": [
     {
       "name": "Button",
       "entrypoint": "src/components/Button.tsx",
-      "sourceFiles": [
-        "src/components/Button.tsx"
-      ],
-      "supportingFiles": [
-        "src/components/Button.stories.tsx",
-        "src/components/Button.module.css"
-      ]
+      "sourceFiles": ["src/components/Button.tsx"],
+      "supportingFiles": ["src/components/Button.stories.tsx", "src/components/Button.module.css"]
     }
   ]
 }
@@ -120,6 +119,7 @@ Component names must be unique. If there are conflicting component names, ask th
 ### 4. Show summary before uploading
 
 Before running the CLI, print a summary so the user can spot any issues:
+
 - List of component names
 - List of theme files
 - Total file count

--- a/plugins/claude/subframe/skills/design/SKILL.md
+++ b/plugins/claude/subframe/skills/design/SKILL.md
@@ -22,15 +22,15 @@ The key value: `/subframe:design` and `/subframe:develop` bridge coding and desi
 
 ## Picking the right tool
 
-| Intent | Tool |
-| --- | --- |
-| Find out what already exists in the project | `list_components`, `list_pages`, `list_snippets`, `list_flows`, `get_project_info` |
-| Build a screen the user navigates to | `design_page` (new) / `edit_page` (targeted change) |
-| Build a reusable building block (Button, Card, ListItem) used inside pages | `design_component` (new) / `edit_component` (targeted change) |
-| Build a small example used inside a design document (e.g. a Button-variants demo) | `design_snippet` (new) / `edit_snippet` (targeted change) |
-| Write or update written design / usage documentation | `write_design_document` |
-| Change project-wide colors, fonts, corners, shadows, typography | `edit_theme` |
-| Remove a page, flow, component, or snippet | `delete_page` / `delete_flow` / `delete_component` / `delete_snippet` |
+| Intent                                                                            | Tool                                                                               |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Find out what already exists in the project                                       | `list_components`, `list_pages`, `list_snippets`, `list_flows`, `get_project_info` |
+| Build a screen the user navigates to                                              | `design_page` (new) / `edit_page` (targeted change)                                |
+| Build a reusable building block (Button, Card, ListItem) used inside pages        | `design_component` (new) / `edit_component` (targeted change)                      |
+| Build a small example used inside a design document (e.g. a Button-variants demo) | `design_snippet` (new) / `edit_snippet` (targeted change)                          |
+| Write or update written design / usage documentation                              | `write_design_document`                                                            |
+| Change project-wide colors, fonts, corners, shadows, typography                   | `edit_theme`                                                                       |
+| Remove a page, flow, component, or snippet                                        | `delete_page` / `delete_flow` / `delete_component` / `delete_snippet`              |
 
 ## MCP Authentication
 
@@ -62,6 +62,7 @@ The first time you're about to call `design_page` / `design_component` / `edit_p
 1. **If the project has codebase context** (working in a repo, recreating a page, importing a design), locate and read the codebase's theme source — `tailwind.config.*`, theme CSS variables, a tokens module. Also read the codebase's most canonical filled component (typically `Button`) to see which token is used where — names and values can match while roles diverge.
 
 2. **Write the comparison** — a brief alignment summary covering colors, fonts, corners, shadows, typography, **and role** (which token is used for what, on both sides). Flag mismatches even when names/values look the same. Watch specifically for:
+
    - **Role divergence** — e.g., the codebase's `brand` token paints focus rings only while a separate `primary` token paints filled-button backgrounds; the Subframe project's convention may have `brand-primary` painting the filled-button background instead. If you need to verify Subframe-side roles, call `get_component_info` on the relevant component to see which tokens it actually references.
    - **Dual-token systems** — shadcn-style `primary` / `primary-foreground`, `destructive` / `destructive-foreground`, etc., where each role pairs a surface token with a content token. The Subframe theme may not have direct equivalents.
 
@@ -75,18 +76,26 @@ If the project has no codebase context, only the empty-theme check applies — s
 
 ## Grounding design calls in real code
 
-Subframe's design AI is far more accurate when the call carries raw code than when it carries paraphrase. "Make the primary darker" leaves a guess; pasting `--color-primary: oklch(0.55 0.18 250)` doesn't. Wherever the codebase already has the source — a component implementation, theme tokens, a similar page — paste it into the call instead of describing it.
+Subframe's design AI is far more accurate when the call carries raw code than when it carries paraphrase. "Make the primary darker" leaves a guess; pasting `--color-primary: oklch(0.55 0.18 250)` doesn't. Wherever the codebase already has the source — a component implementation, theme tokens, a similar page — pass it into the call instead of describing it.
 
-**Default to pasting full files when they exist.** Under-including is generally worse than over-including. Use the format:
+`design_page`, `design_component`, and `edit_component` take grounding through the `references` parameter — a list of `{ source, usage }` entries where `source` is one of:
+
+- `{ kind: "subframe", id }` — an existing Subframe page, component, or snippet (by ID or name; resolved server-side, no need to inline its code)
+- `{ kind: "code", content }` — raw code from the codebase (the surface to recreate, data types, usage patterns)
+- `{ kind: "image", url }` — a Subframe-hosted upload URL (e.g. an image the user pasted from Subframe). Uploads only happen inside the Subframe app — there is no MCP or CLI upload, so skip this kind unless you were given an upload URL. Local files or arbitrary URLs are rejected; up to 5 images are used per call, each applied per its own `usage` note.
+
+`usage` says how the generator should use THAT reference — e.g. "match this page's layout and header" or "recreate this mockup exactly". Always write it: the generator sees only the description plus the references, not your reasoning. (`edit_page` / `edit_snippet` are node-targeted and take no grounding.)
+
+**Default to pasting full files when they exist.** Under-including is generally worse than over-including. Head each `content` with its path:
 
 ```
 // src/components/Button.tsx
 <full file content>
 ```
 
-Group related files in adjacent blocks (component + stories + CSS module).
+Group related files as separate `code` references (component + stories + CSS module), each with its own usage note.
 
-**Don't paste what the AI already has.** For `edit_component`, the current Subframe code is already on the server — don't echo it back. Read it with `get_component_info` so your description can target exactly what differs. Prefer the most efficient form: plain language when the change doesn't depend on any code the AI hasn't seen ("change padding from 4 to 6, add a hover state"); otherwise reference code scaled to what's needed — a targeted diff or code snippet when the Subframe code already resembles the target, a full file when handing over a wholesale target, a sibling pattern, or related types. (`edit_page` and `edit_snippet` use a different, node-targeted model — see their own sections.)
+**Don't paste what the AI already has.** For `edit_component`, the current Subframe code is already on the server — don't echo it back. Read it with `get_component_info` so your description can target exactly what differs. Prefer the most efficient form: plain language when the change doesn't depend on any code the AI hasn't seen ("change padding from 4 to 6, add a hover state"); otherwise pass reference code scaled to what's needed — a targeted diff or code snippet when the Subframe code already resembles the target, a full file when handing over a wholesale target, a sibling pattern, or related types — as `code` references with usage notes. (`edit_page` and `edit_snippet` use a different, node-targeted model — see their own sections.)
 
 **Soft cap on very large files (~500 LOC combined).** When trimming, keep verbatim:
 
@@ -115,11 +124,11 @@ Include in the description:
 
 ### For snippet design (`design_snippet`)
 
-See the `design_snippet` section below for `codeContext` / `additionalReferences` parameter use. `edit_snippet` takes no grounding context — it's a node-targeted edit (see its section below).
+`design_snippet` takes the same `references` input as the other design tools — ground it the same way (the codebase implementation the snippet should mirror as `code`, existing Subframe entities as `subframe`). `edit_snippet` takes no grounding context — it's a node-targeted edit (see its section below).
 
 ### For page design (`design_page`)
 
-See [Preparing codeContext](#preparing-codecontext) below for the page-specific rule about leaving Subframe component references as-is and inlining everything else. The general grounding rules above (default to full files, paste styles verbatim, soft cap with trimming) layer on top. (`edit_page` is a node-targeted edit, not a `codeContext`-grounded design call — see its section below.)
+See [Preparing references](#preparing-references) below for the page-specific rule about leaving Subframe component references as-is and inlining everything else. The general grounding rules above (default to full files, paste styles verbatim, soft cap with trimming) layer on top. (`edit_page` is a node-targeted edit, not a reference-grounded design call — see its section below.)
 
 ### For theme edits (`edit_theme`)
 
@@ -151,6 +160,7 @@ When the user asks you to design, recreate, or redesign a page that uses non-tri
 
 1. **Run the project audit** — `list_components` (and `get_project_info` if you haven't yet).
 2. **Inventory the components the page renders with their status and decision.** Output the list verbatim, even when the conclusion seems obvious
+
    - **Missing entirely** → `design_component`
    - **Exists but visually doesn't match the source/spec** → `edit_component` (existing components keep their identity; existing usages are updated)
    - **Exists and matches** → reference directly in the page design
@@ -163,6 +173,7 @@ When the user asks you to design, recreate, or redesign a page that uses non-tri
    SettingsCard: missing → design_component
    ProfileMenu: exists, matches → reference
    ```
+
 3. **Write the dependency list before any `design_component`/`edit_component` calls.** For each new or edited component in the batch, list the other components in the batch that it visually embeds. Output it verbatim, even when the list is short. For example:
 
    ```
@@ -172,9 +183,11 @@ When the user asks you to design, recreate, or redesign a page that uses non-tri
    ```
 
    Many components embed other components — a Card with an action footer holds a Button, a Form holds Text Fields, a ListItem holds an Avatar. If you skip writing the list, you will miss these.
+
 4. **Group into waves from the dependency list, then run waves sequentially.** A component goes in Wave N if all its deps are in waves < N or already ready as-is. Kick off everything in a wave in parallel, `wait_for_jobs` on the whole wave, then start the next wave. `wait_for_jobs` on the final wave before kicking off the page, so the page design sees up-to-date components.
 
    Example: page needs a new `Button`, a new `Alert`, and a new `SettingsCard` (whose footer renders a Save Button).
+
    - Wave 1: `Button` + `Alert` in parallel → `wait_for_jobs` both.
    - Wave 2: `SettingsCard` → `wait_for_jobs`.
    - Then `design_page`.
@@ -196,27 +209,28 @@ Use `design_page` when:
 
 How much context to gather and how many variations to generate depends on the task:
 
-| Task                                | Context                                                                                                                                            | Variations                              |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| **New page (open-ended)**           | Data types (`codeContext`)                                                                                                                         | 4 — explore the design space            |
-| **New page (with reference pages)** | Reference pages (`additionalReferences` if in Subframe, `codeContext` if not), data types (`codeContext`)                                               | 1-2 — stay close to the reference pages |
-| **Redesigning existing UI**         | The current page (`additionalReferences` if in Subframe, `codeContext` if not; note what to keep vs change in the description)                          | 2-4 — depending on how open-ended       |
-| **Recreating an existing UI**       | The current page's exact markup and styles (`codeContext`)                                                                                         | 1 — recreate the UI from code exactly   |
+| Task                                | Context                                                                                                                             | Variations                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| **New page (open-ended)**           | Data types (`code` reference)                                                                                                       | 4 — explore the design space            |
+| **New page (with reference pages)** | Reference pages (`subframe` reference if in Subframe, `code` if not), data types (`code`)                                           | 1-2 — stay close to the reference pages |
+| **Redesigning existing UI**         | The current page (`subframe` reference if in Subframe, `code` if not; the usage note says what to keep vs change)                    | 2-4 — depending on how open-ended       |
+| **Recreating an existing UI**       | The current page's exact markup and styles (`code` reference, usage "recreate this exactly")                                        | 1 — recreate the UI from code exactly   |
 
 **Always include when available:**
 
-- The existing page being discussed and similar existing pages (the single most valuable context) — pass them via `additionalReferences` by ID or name (e.g. a page ID from a pasted MCP link, or a variation page ID the user referenced). `additionalReferences` resolves any Subframe page, snippet, or component; use `codeContext` for code that only exists in the codebase.
-- Components or patterns the user refers to or explicitly mentions — `additionalReferences` for components already in the Subframe project, `codeContext` for patterns or code not yet in Subframe
-- Data types/interfaces for what the page will display (via `codeContext`)
+- The existing page being discussed and similar existing pages (the single most valuable context) — pass them as `subframe` references by ID or name (e.g. a page ID from a pasted MCP link, or a variation page ID the user referenced). A `subframe` reference resolves any Subframe page, snippet, or component; use a `code` reference for code that only exists in the codebase.
+- Components or patterns the user refers to or explicitly mentions — `subframe` references for components already in the Subframe project, `code` references for patterns or code not yet in Subframe
+- Data types/interfaces for what the page will display (as a `code` reference)
+- A mockup or screenshot the user supplied through Subframe — as an `image` reference (Subframe-hosted upload URLs only)
 
-#### Preparing `codeContext`
+#### Preparing references
 
 The general "paste real code, soft cap with verbatim styling" rules in [Grounding design calls in real code](#grounding-design-calls-in-real-code) apply here too. The page-specific addition below is the Subframe-vs-non-Subframe component handling rule.
 
-When including code in `codeContext`, distinguish between components in the Subframe project vs not (`list_components` is the source of truth):
+When including code in a `code` reference, distinguish between components in the Subframe project vs not (`list_components` is the source of truth):
 
 - **References to components that already exist in the project** — leave as-is. Subframe will resolve them from the project.
-- **References to components that don't exist in the project yet** — either design them first with `design_component` (see [Before designing a page](#before-designing-a-page)), or inline their rendered JSX + Tailwind classes into `codeContext`.
+- **References to components that don't exist in the project yet** — either design them first with `design_component` (see [Before designing a page](#before-designing-a-page)), or inline their rendered JSX + Tailwind classes into the reference content.
 - **References to non-component application code** — always inline. See [What belongs as a Subframe component](#what-belongs-as-a-subframe-component) for the distinction.
 
 When you inline a component, expand it into its JSX markup (inputs, buttons, layout, Tailwind classes). If that expanded markup has more component references, evaluate those using the same process.
@@ -225,12 +239,12 @@ When you inline a component, expand it into its JSX markup (inputs, buttons, lay
 
 Each variation is an object with a `name` (short name) and `description` (a few sentence prompt describing the design direction).
 
-**When you have reference pages** (`additionalReferences`), use fewer variations (1-2) and keep them grounded in the reference. The variations should refine or extend the existing design, not diverge from it. For example:
+**When you have reference pages** (`references`), use fewer variations (1-2) and keep them grounded in the reference. The variations should refine or extend the existing design, not diverge from it. For example:
 
 - `{ "name": "Adapted layout", "description": "Follow the same layout as the reference page but adapted for [new content]" }`
 - `{ "name": "Compact data-dense", "description": "Same structure as the reference but with a more compact, data-dense layout." }`
 
-**When starting from scratch** (no `additionalReferences`), use more variations (4) to explore the design space:
+**When starting from scratch** (no `references`), use more variations (4) to explore the design space:
 
 - `{ "name": "Data table", "description": "Compact data table with inline actions and bulk operations." }`
 - `{ "name": "Card grid", "description": "Card-based layout with visual hierarchy and quick filters." }`
@@ -244,8 +258,8 @@ More variations = more exploration. Fewer = more focused. Default to fewer when 
 When designing multiple related pages (flows, CRUD, etc.):
 
 1. Design the primary page first with more variations to establish the direction.
-2. After the user has reviewed the variations in the flow editor, design remaining pages passing the relevant variation page(s) via `additionalReferences`. Have the user paste an MCP link to the variation they want as reference, or use `get_flow_info` with the `flowId` to enumerate the pages in the flow and ask which to use.
-3. Use the same `flowName` to group related pages together.
+2. After the user has reviewed the variations in the flow editor, design each remaining page passing the chosen page's ID as `sourcePageId` — the generation starts from that page's EXACT structure and changes only what the description asks, so shared header, nav, and layout carry over by construction. Have the user paste an MCP link to the variation they want, or use `get_flow_info` with the `flowId` to enumerate the pages in the flow and ask which to use. Add `references` for anything else the new screen should draw on.
+3. Use the same `flowName` to group related pages together. Don't pack multiple screens into variations — variations are independent alternatives of the SAME screen.
 
 ### `edit_page` — targeted edits to an existing page
 
@@ -273,11 +287,11 @@ For `design_page`, present the returned `flowUrl` as a clickable markdown link. 
 
 From there, the user may continue refining in Subframe or return here and ask you to implement the design in code. Do NOT ask the user which variation they prefer or present variation options as a multiple choice in chat. Simply present the flow URL and let them know they can ask you to implement once they're ready.
 
-If you need to enumerate the variation pages programmatically (e.g., to reference one in `additionalReferences` or to read its current code with `get_page_info`), call `wait_for_jobs` with the `jobId` first, then `get_flow_info` with the `flowId`. Reading too early may return only the variations that have finished by that moment.
+If you need to enumerate the variation pages programmatically (e.g., to reference one in `references` or `sourcePageId`, or to read its current code with `get_page_info`), call `wait_for_jobs` with the `jobId` first, then `get_flow_info` with the `flowId`. Reading too early may return only the variations that have finished by that moment.
 
 Internally track the `flowId` returned by `design_page`. Don't surface it to the user. Use it with `get_flow_info` for follow-up flow-level operations, or pass the same `flowName` on subsequent `design_page` calls to keep new variations grouped in the same flow.
 
-For `/subframe:develop`, `additionalReferences`, or `edit_page`, use specific page IDs the user has referenced (via pasted MCP link or while iterating in the editor), or call `get_flow_info` to look them up by name — `design_page` itself doesn't return individual page IDs since all variations land as separate pages on the canvas.
+For `/subframe:develop`, `references`, `sourcePageId`, or `edit_page`, use specific page IDs the user has referenced (via pasted MCP link or while iterating in the editor), or call `get_flow_info` to look them up by name — `design_page` itself doesn't return individual page IDs since all variations land as separate pages on the canvas.
 
 ## Components
 
@@ -288,10 +302,12 @@ Components are reusable UI building blocks (Button, Card, ListItem, Toggle, etc.
 Subframe components are **visual/presentational primitives** — the reusable UI building blocks that get composed into pages. Be deliberate about what gets promoted to a component vs. what stays inline in a page.
 
 **Make it a component if it:**
+
 - Renders pure UI: buttons, inputs, cards, modals, badges, alerts, list items, layout primitives (containers, stacks, grids), etc.
 - Will be reused across multiple pages, or has variants worth defining once
 
 **Keep it inline (in the page, not a component) if it:**
+
 - Fetches data, calls APIs, or manages application state
 - Wires together business logic (form submission handlers, validation flows, page-level orchestration)
 - Is a one-off composition specific to a single page
@@ -303,10 +319,10 @@ When unsure, quickly read the source. If it imports data-fetching libraries, sto
 
 Use `design_component` to create something that should be a Subframe component (see [What belongs as a Subframe component](#what-belongs-as-a-subframe-component)). Pass:
 
-- `description` — what the component is and how it should look/behave. **Paste real code, don't paraphrase** — see [Grounding design calls in real code](#grounding-design-calls-in-real-code) for what to include (canonical source, stories, CSS modules, prop types, relevant theme tokens) and verbosity rules. Apply the Subframe-vs-application rule from [Preparing codeContext](#preparing-codecontext): leave references to components that already exist in this Subframe project as-is, inline anything else.
+- `description` — what the component is and how it should look/behave.
+- `references` (optional) — the grounding material with per-reference usage notes. **Pass real code, don't paraphrase** — see [Grounding design calls in real code](#grounding-design-calls-in-real-code) for what to include (canonical source, stories, CSS modules, prop types, relevant theme tokens) and verbosity rules, plus a mockup/screenshot as an `image` reference when the user supplied one through Subframe. Apply the Subframe-vs-application rule from [Preparing references](#preparing-references): pass components that already exist in this Subframe project as `subframe` references, inline anything else as `code`.
 - `name` — the component name (PascalCase, e.g., "PrivacyToggle")
 - `projectId` — usually inferred from `.subframe/sync.json`
-- `additionalReferences` (optional) — IDs or names of existing Subframe pages, snippets, or components to use as design context (resolved server-side, no need to inline their code).
 
 Returns `componentId` (immediately referenceable in other tools), `componentUrl` (open this in the editor to watch the design happen), and `jobId` (pass to `wait_for_jobs` before reading back via `get_component_info` or referencing in another design call).
 
@@ -314,7 +330,7 @@ Returns `componentId` (immediately referenceable in other tools), `componentUrl`
 
 Use `edit_component` for targeted changes to a component already in the project. Call `get_component_info` first so your description can target exactly what differs. The design AI already has the current Subframe code — only paste outside reference code when the change depends on something the AI can't see (a codebase implementation to match, a sibling component, a design spec). See [Grounding design calls in real code](#grounding-design-calls-in-real-code) for what to include and how to trim.
 
-Pass one of `id`, `name`, or `url` plus a `description`; optionally `additionalReferences` to point the AI at related Subframe pages, snippets, or components. Returns `componentUrl` and `jobId`. Edits propagate to every page using the component, so confirm with the user before making structural changes.
+Pass one of `id`, `name`, or `url` plus a `description`; optionally `references` to point the AI at related Subframe pages/snippets/components, outside code, or an image to match. Returns `componentUrl` and `jobId`. Edits propagate to every page using the component, so confirm with the user before making structural changes.
 
 The same component cannot be edited by two agents simultaneously — if another conversation is already working on it, the tool returns the in-progress URL and you should wait or ask the user.
 
@@ -332,8 +348,7 @@ Use `design_snippet` when the user wants to illustrate something in a design doc
 
 - `description` — what to show
 - `name` — optional; defaults to "AI Generated Snippet"
-- `codeContext` (optional) — raw outside code that grounds the snippet (the codebase implementation it should mirror, related types, the specific usage example it illustrates).
-- `additionalReferences` (optional) — IDs or names of existing Subframe pages, snippets, or components to use as design context (resolved server-side, no need to inline their code).
+- `references` (optional) — the same grounding input as the other design tools: outside code as `code` entries (the codebase implementation the snippet should mirror, related types, the usage example it illustrates), existing Subframe pages/snippets/components as `subframe` entries (resolved server-side, no need to inline their code), plus an `image` when the user supplied one through Subframe — each with a `usage` note.
 
 Returns `snippetId` and `snippetUrl`. Embed the snippet in a design document with `<div data-type="component-example" data-component-id="<snippetId>"></div>` (see the design documents section).
 
@@ -367,6 +382,7 @@ Design documents are for **design judgment that Subframe's structured data can't
 Restating any of that in a doc is wasted space. Reach instead for the layer above: when to use what, how to compose, what it should say, what to avoid.
 
 **Belongs in a design doc:**
+
 - Usage hierarchy and taxonomy
 - Variant meaning — what each variant communicates to the user
 - Sizing rules
@@ -376,12 +392,12 @@ Restating any of that in a doc is wasted space. Reach instead for the layer abov
 - Do's and don'ts framed as design judgment
 
 **Does NOT belong in a design doc:**
+
 - Prop tables or API documentation — the design AI reads the component code already
 - Theme token values (hex codes, pixel spacing, shadow definitions, radius values) — the theme already holds these. If the project's theme is wrong or empty, fix the theme via `edit_theme`; don't paper over it in a doc.
 - Inline JSX or Tailwind class examples — these should be embedded snippets instead
 - Common design standards — if any designer would follow a pattern by default, don't restate it. Only document practices unique to this design system. When a common standard does hold particular importance, write the project-specific angle ("Confirm before destructive actions — restate the noun in the dialog, e.g. 'Delete survey' not 'Are you sure?'"), not the standard itself.
 - Anything trivially derivable from the component source or the theme
-
 
 ### `write_design_document`
 
@@ -429,11 +445,11 @@ Paste each file in a fenced block headed by its path (`// tailwind.config.ts`). 
 
 Read the user's prompt and classify before invoking:
 
-| Risk | Operations | Action |
-| --- | --- | --- |
-| Low | Adding tokens, tweaking values | Call directly; mention what changed after |
-| Medium | Renaming tokens, broad multi-token tweaks | Briefly note the scope (whole project) and call |
-| High | Anything that deletes tokens, replaces the palette wholesale, or implies "remove / strip / replace existing X" | **Confirm with the user before calling.** Spell out what will be deleted and that pages/components using those tokens will be updated to use hardcoded values (which would then require project version history to undo). |
+| Risk   | Operations                                                                                                     | Action                                                                                                                                                                                                                    |
+| ------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Low    | Adding tokens, tweaking values                                                                                 | Call directly; mention what changed after                                                                                                                                                                                 |
+| Medium | Renaming tokens, broad multi-token tweaks                                                                      | Briefly note the scope (whole project) and call                                                                                                                                                                           |
+| High   | Anything that deletes tokens, replaces the palette wholesale, or implies "remove / strip / replace existing X" | **Confirm with the user before calling.** Spell out what will be deleted and that pages/components using those tokens will be updated to use hardcoded values (which would then require project version history to undo). |
 
 When in doubt about the risk of a prompt, assume High risk and confirm.
 
@@ -465,9 +481,9 @@ When a delete tool refuses because of references, surface what it would affect t
 
 The user reviews and refines designs in the Subframe editor, not in code. When they come back asking to combine ideas, refine a specific direction, or iterate further:
 
-- **They reference a specific variation** (by pasted MCP link, by name, or by describing it). If you need to find the variation's `pageId`, call `get_flow_info` with the `flowId` from the original `design_page` response — it returns the pages in the flow with names and IDs. Then use `edit_page` with that page's id for targeted changes, or call `design_page` with the page passed via `additionalReferences` if they want a fresh set of options grounded in that direction.
-- **They want to mix variations** ("I like the layout from variation 1 but the colors from variation 3"). Ask them to paste the MCP links of the variations they want to combine (or use `get_flow_info` to look up page IDs by name), then call `design_page` with those pages via `additionalReferences` and a description of the combination.
-- **They want to start over** ("none of these are right"). Call `design_page` again with a refined description and any reference pages via `additionalReferences`. Use the same `flowName` to keep related work grouped.
+- **They reference a specific variation** (by pasted MCP link, by name, or by describing it). If you need to find the variation's `pageId`, call `get_flow_info` with the `flowId` from the original `design_page` response — it returns the pages in the flow with names and IDs. Then use `edit_page` with that page's id for targeted changes, or call `design_page` with the page as `sourcePageId` (to evolve its exact structure) or as a `subframe` reference (for a fresh set of options grounded in that direction).
+- **They want to mix variations** ("I like the layout from variation 1 but the colors from variation 3"). Ask them to paste the MCP links of the variations they want to combine (or use `get_flow_info` to look up page IDs by name), then call `design_page` with those pages as `subframe` references whose usage notes say what to take from each, and a description of the combination.
+- **They want to start over** ("none of these are right"). Call `design_page` again with a refined description and any reference pages as `subframe` references. Use the same `flowName` to keep related work grouped.
 - **They want to iterate on a component or snippet**. Use `edit_component` / `edit_snippet` for targeted changes; the resource keeps its identity and existing usages stay wired up.
 
 You don't have to read the generated code by default — Subframe renders the designs and the user reviews them visually in the editor, so summarizing them in chat usually isn't useful. When reading the code would genuinely help (the user asks what was generated, you're picking which design to extend, etc.), call `wait_for_jobs` if necessary and then the required `get_*_info` calls.

--- a/plugins/claude/subframe/skills/develop/SKILL.md
+++ b/plugins/claude/subframe/skills/develop/SKILL.md
@@ -80,6 +80,7 @@ To discover what exists in the project, use `list_pages`, `list_components`, or 
 Read design documentation alongside the design: `get_project_info` returns project-level `docs` (broad principles), and `get_component_info` returns each component's `designDocuments` (component-specific usage guidance). Pick these up before implementing so you respect documented constraints.
 
 Get the `projectId` from `.subframe/sync.json`. If `.subframe/sync.json` doesn't exist or doesn't contain a `projectId`, call `list_projects` to get the available projects. Each project includes a `projectId`, `name`, `teamId`, and `teamName`.
+
 - **One project**: Use it automatically.
 - **Multiple projects**: Always ask the user which project to use. Present each project with its `teamName` to disambiguate. If the user already mentioned a specific team or project name, match it against the `teamName` and `name` fields — but still confirm before proceeding. Never silently pick a project when multiple exist.
 
@@ -179,14 +180,14 @@ When diffing the updated design against the existing code, if there are design c
 
 ## MCP Tools Reference
 
-| Tool                 | Purpose                                                  | Key Parameters                      |
-| -------------------- | -------------------------------------------------------- | ----------------------------------- |
-| `get_page_info`      | Fetch page code                                          | `url`, `id`, or `name`; `projectId` |
-| `get_component_info` | Fetch component code + attached design doc               | `url`, `id`, or `name`; `projectId` |
-| `get_project_info`   | Fetch project metadata + project-level design docs       | `projectId`                         |
-| `get_flow_info`      | Enumerate pages in a flow                                | `id`, `name`, or `url`; `projectId` |
-| `list_pages`         | List all pages                                           | `projectId`                         |
-| `list_components`    | List all components                                      | `projectId`                         |
-| `list_flows`         | List all flows                                           | `projectId`                         |
-| `get_theme`          | Get Tailwind config                                      | `projectId`, `cssType`              |
-| `wait_for_jobs`      | Wait for in-flight design jobs to finish before reading  | `jobIds` (1-10)                     |
+| Tool                 | Purpose                                                 | Key Parameters                      |
+| -------------------- | ------------------------------------------------------- | ----------------------------------- |
+| `get_page_info`      | Fetch page code                                         | `url`, `id`, or `name`; `projectId` |
+| `get_component_info` | Fetch component code + attached design doc              | `url`, `id`, or `name`; `projectId` |
+| `get_project_info`   | Fetch project metadata + project-level design docs      | `projectId`                         |
+| `get_flow_info`      | Enumerate pages in a flow                               | `id`, `name`, or `url`; `projectId` |
+| `list_pages`         | List all pages                                          | `projectId`                         |
+| `list_components`    | List all components                                     | `projectId`                         |
+| `list_flows`         | List all flows                                          | `projectId`                         |
+| `get_theme`          | Get Tailwind config                                     | `projectId`, `cssType`              |
+| `wait_for_jobs`      | Wait for in-flight design jobs to finish before reading | `jobIds` (1-10)                     |


### PR DESCRIPTION
## Summary

Updates the Claude plugin skills and the docs site for upcoming design tool changes.

### Skills (`plugins/claude/subframe/skills/`)

- **design** — documents the unified `references` parameter on `design_page` / `design_component` / `edit_component` / `design_snippet` (`{ source, usage }` entries with `subframe` / `code` / `image` source kinds) and the new `sourcePageId` on `design_page`, replacing the `codeContext` / `additionalReferences` parameters.
- **develop / bulk-import** — formatting-only changes.

### Docs (`packages/docs/`)

- **MCP server guide** — tool tables updated for the new params, a new "Design references" section documenting the `references` shape and limits, and rows for the new `screenshot_page` and `search_docs` tools.
- **Ask AI learn docs** — updated for the docked Ask AI panel (toolbar button / Cmd+/, available across project pages), variations landing as pages in a flow, and the chat history menu. Removed the retired URL-reference feature and rerouted personalize-AI through project settings.
- **Quickstart / editor overview / AI agents guide** — removed "Ask AI mode" framing (the mode switcher is now Design / Prototype / Code only).
- Stale screenshots and videos are marked with `{/* TODO: Update image */}` comments for a visual pass after release.