### PR TITLE
Update Share designs docs for multi-email invites

### DIFF
--- a/packages/docs/learn/design-mode/share-designs.mdx
+++ b/packages/docs/learn/design-mode/share-designs.mdx
@@ -11,8 +11,6 @@ All team members have access to your designs by default. The easiest way to shar
 2. Enter one or more teammate emails in the input field, separated by commas
 3. Select a role, then press **Invite**. Everyone you invite receives an email to view the designs, and an invite to join your team if they're not already a member.
 
-<Tip>Existing Subframe users you invite are added to the team right away and get a prompt to confirm the new team on their next visit.</Tip>
-
 ## Share public view-only link
 
 1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar

--- a/packages/docs/learn/design-mode/share-designs.mdx
+++ b/packages/docs/learn/design-mode/share-designs.mdx
@@ -8,8 +8,10 @@ All team members have access to your designs by default. The easiest way to shar
 ## Invite teammates
 
 1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
-2. Type your teammates email in the input field
-3. Press **Invite**. They will receive an email to view the designs, and an invite to join your team if they're not already a member.
+2. Enter one or more teammate emails in the input field, separated by commas
+3. Select a role, then press **Invite**. Everyone you invite receives an email to view the designs, and an invite to join your team if they're not already a member.
+
+<Tip>Existing Subframe users you invite are added to the team right away and get a prompt to confirm the new team on their next visit.</Tip>
 
 ## Share public view-only link
 


### PR DESCRIPTION
Updates the **Share designs** doc to reflect the current Share dialog: you can now invite multiple teammates at once with comma-separated emails, and existing users are added to the team directly and prompted to confirm on their next visit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ3sy6pDbCQcNBCdLCLdNJ)_