### PR TITLE
Correct Share button label and location in editor docs

### DIFF
--- a/packages/docs/learn/design-mode/share-designs.mdx
+++ b/packages/docs/learn/design-mode/share-designs.mdx
@@ -7,13 +7,13 @@ All team members have access to your designs by default. The easiest way to shar
 
 ## Invite teammates
 
-1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
+1. Click the **Share** button in the top left, next to your avatar
 2. Enter one or more teammate emails in the input field, separated by commas
 3. Select a role, then press **Invite**. Everyone you invite receives an email to view the designs, and an invite to join your team if they're not already a member.
 
 ## Share public view-only link
 
-1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
+1. Click the **Share** button in the top left, next to your avatar
 2. Click the toggle to enable public sharing
 3. Copy the link that appears
 

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -88,6 +88,6 @@ Multiple team members can edit simultaneously. See who's viewing or editing with
   <img src="/images/editor/editor-collaborators.png" alt="Editor collaboration showing the team members and avatars" />
 </Frame>
 
-Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar, to invite team members or create view-only links. Set roles (viewer/editor) and toggle public preview access.
+Click the **Share** button in the top left, next to your avatar, to invite team members or create view-only links. Set roles (viewer/editor) and toggle public preview access.
 
-{/* TODO: Update screenshot — the Share control is now a user-plus icon button next to your avatar at the top of the left panel */}
+{/* TODO: Update screenshot — the Share control is now a text **Share** button in the top left, next to your avatar */}

--- a/packages/docs/learn/prototype-mode/overview.mdx
+++ b/packages/docs/learn/prototype-mode/overview.mdx
@@ -73,7 +73,7 @@ This will download your prototype code as a Vite app in a zip file.
 
 ## Sharing prototypes
 
-1. Click the **Share** <Icon icon="user-plus" size={16} /> button at the top of the left panel, next to your avatar
+1. Click the **Share** button in the top left, next to your avatar
 2. Toggle on **Share link to latest prototype**
 3. Copy and paste the generated link
 


### PR DESCRIPTION
The Share control is now a text **Share** button in the editor's top left (next to your avatar), shared across Design, Prototype, and Code modes — no longer a `user-plus` icon. Updates the stale reference in **Share designs**, **Editor overview** (including an outdated screenshot TODO), and **Prototype mode overview**.