### PR TITLE
Docs: fix Ask AI quick edits location and clarify cross-project page import

### DIFF
--- a/packages/docs/learn/ask-ai/making-quick-edits.mdx
+++ b/packages/docs/learn/ask-ai/making-quick-edits.mdx
@@ -19,11 +19,9 @@ You can make targeted edits to specific elements using [quick actions](/learn/de
 3. Select **Ask AI to edit...**
 4. Type what you want to change and press <kbd>Enter</kbd>
 
-You can also ask AI from the inspector panel:
+You can also make a quick edit from the floating toolbar. Select an element, type your change into the **Apply quick edit to…** input, and press <kbd>Enter</kbd>.
 
-<Frame>
-  <img src="/images/ask-ai/inline-ask-ai-inspector.png" alt="Quick edits in the inspector panel" />
-</Frame>
+{/* TODO: Update image — add a screenshot of the quick edit input in the floating toolbar */}
 
 AI replaces or modifies the selected element based on your prompt.
 

--- a/packages/docs/learn/components/overview.mdx
+++ b/packages/docs/learn/components/overview.mdx
@@ -234,7 +234,7 @@ For more information, see [syncing components](/concepts/syncing-components).
 Copy components and pages from one of your other Subframe projects into the current one. Each selection brings along the dependencies it needs to render — nested components, theme tokens, fonts, custom icons, and image assets.
 
 1. Open **Components** under **Design System** in the left sidebar
-2. Click **Import from...** (top right) and select **Another project**
+2. Click **Import** (top right) and select **Import from project...**
 3. Pick the source project from the dropdown
 4. Browse or search the source project's components and pages — click any item to preview it on the right
 5. Check the box on each item you want, then click **Import**

--- a/packages/docs/learn/projects/overview.mdx
+++ b/packages/docs/learn/projects/overview.mdx
@@ -68,7 +68,7 @@ Only Admins and Editors can create, rename, duplicate, and delete projects.
 <AccordionGroup>
 <Accordion title="Can I copy/paste between projects?">
 
-No, you can't copy/paste elements between projects. However, you can [import components from another project](/learn/components/overview#importing-from-another-project).
+You can't copy/paste elements between projects, but you can [import both components and pages from another project](/learn/components/overview#importing-from-another-project).
 
 </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Two Ask AI / projects doc corrections:

- **Quick edits** — inline Ask AI edits happen from the floating toolbar near a selected element, not the inspector panel. Removes the outdated inspector screenshot reference.
- **Cross-project import** — the projects FAQ implied only *components* can be imported from another project. Pages can be imported too — corrects the FAQ and aligns the import menu labels in the components overview with the current UI (**Import** > **Import from project...**).