### PR TITLE
Document @ref chip hover preview in adding-context

### DIFF
--- a/packages/docs/learn/ask-ai/adding-context.mdx
+++ b/packages/docs/learn/ask-ai/adding-context.mdx
@@ -12,4 +12,6 @@ Type <kbd>@</kbd> anywhere in the chat bar to reference something in your projec
 
 Ask AI pulls in each reference and grounds its response in those designs.
 
+Hover over a page, component, or snippet chip to preview what it references without leaving the chat.
+
 <Note>The page you're working on is always included as context automatically. Use <kbd>@</kbd> to bring in *other* pages, components, snippets, or docs.</Note>


### PR DESCRIPTION
Adds a line to the "Adding context with @" doc noting that hovering a page, component, or snippet reference chip shows a visual preview of what it references.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyEApjnXFc134GM5eyWrKD)_