### PR TITLE
Document multiple image uploads in Ask AI image-to-design

### DIFF
--- a/packages/docs/learn/ask-ai/image-to-design.mdx
+++ b/packages/docs/learn/ask-ai/image-to-design.mdx
@@ -5,13 +5,15 @@ description: Upload images to prompt AI when generating designs.
 
 Upload screenshots or mockups and Ask AI will recreate designs using your components and theme.
 
-## Upload an image
+## Upload images
 
-1. Click the **image icon** in the Ask AI toolbar or drag an image directly into the prompt area.
-2. Add a prompt describing how to use the image
+1. Click the **image icon** in the Ask AI toolbar or drag images directly into the prompt area. Add more than one to reference several screens or mockups in a single prompt.
+2. Add a prompt describing how to use the images
 3. Press <kbd>Enter</kbd> to generate
 
-AI analyzes the image and creates 1-4 variations that match the structure using your Subframe components.
+Each image appears as a thumbnail in the prompt area. Hover a thumbnail and click the **x** to remove it before generating.
+
+AI analyzes the images and creates 1-4 variations that match the structure using your Subframe components.
 
 Supported formats: PNG, JPG, JPEG, WebP
 


### PR DESCRIPTION
Updates the image-to-design guide to reflect that Ask AI now accepts more than one image per prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_019UCmDygS9cw7x2Nutvc764)_