### PR TITLE
Document the insert tool (F/T) in Adding elements

### DIFF
--- a/packages/docs/learn/design-mode/adding-elements.mdx
+++ b/packages/docs/learn/design-mode/adding-elements.mdx
@@ -3,7 +3,7 @@ title: Adding elements
 description: Add elements to your design using quick insert or drag-and-drop.
 ---
 
-There are two main ways to add elements to your design in Subframe: quick insert and the insert panel.
+There are a few ways to add elements to your design in Subframe: quick insert, the insert tool, and the insert panel.
 
 ## Method 1: Quick insert (recommended)
 
@@ -31,7 +31,18 @@ You can also use these keyboard shortcuts after selecting an element:
 - Quick insert left: <kbd>Ctrl</kbd> + <kbd>J</kbd>
 - Quick insert right: <kbd>Ctrl</kbd> + <kbd>L</kbd>
 
-## Method 2: Drag and drop from the Insert panel
+## Method 2: Insert tool
+
+Press a shortcut to pick up an element, then click on the canvas to drop it in.
+
+1. Press <kbd>F</kbd> to pick up a **stack**, or <kbd>T</kbd> to pick up a **text** element
+2. Move your cursor over the canvas—a dashed preview follows your cursor and a line marks where the element will be inserted
+3. Click to place the element
+4. Press <kbd>V</kbd> or <kbd>Esc</kbd> to return to the select tool without inserting
+
+Text elements enter edit mode as soon as they're placed, so you can start typing right away.
+
+## Method 3: Drag and drop from the Insert panel
 
 <video
   autoPlay


### PR DESCRIPTION
Adds a section covering the keyboard-driven insert tool: press F to place a stack, T to place text, and V/Esc to return to the select tool.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191UiYAwNd4UaHebndiVKK2)_