### PR TITLE
Document get_theme availableFonts and breakpoints in MCP reference

### DIFF
--- a/packages/docs/guides/mcp-server.mdx
+++ b/packages/docs/guides/mcp-server.mdx
@@ -101,7 +101,7 @@ Read existing docs first via `get_project_info` (project-level) or `get_componen
 
 | Tool | Description | Key inputs | Returns |
 | --- | --- | --- | --- |
-| `get_theme` | Generate the Tailwind theme for the project | `projectId`, `cssType?` | `theme` config |
+| `get_theme` | Generate the Tailwind theme for the project, along with its responsive breakpoints and the font families available to use | `projectId`, `cssType?` | `theme` config, `availableFonts`, `breakpoints` |
 | `edit_theme` | Edits the project's visual theme (colors, fonts, corners, shadows, typography) from a natural-language prompt. Applies immediately to the whole project. Supports adding tokens, changing token values, renaming tokens, and **deleting tokens (destructive — references in designs are replaced with the token's concrete value at deletion time)**. | `description`, `projectId` | `themeUrl` |
 | `search_icons` | Search the project's icon library by describing what you want (e.g. "warning triangle", "shopping cart"). Icon sets vary by project, so use this to find real names rather than assuming a set — reference a result's exact name in the code you pass to `edit_page`, `edit_snippet`, or a design tool | `query`, `projectId?` | `iconLibraryStatus`, `iconLibrarySize`, `icons` (array of `name`, `hints`) |
 


### PR DESCRIPTION
Updates the `get_theme` row in the MCP server reference to reflect its current return shape: the tool now also returns `availableFonts` (the exact font-family names available in the project, including uploaded custom fonts) and `breakpoints`, and the description notes both.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111MH2dpgpQznLBrujZ5eFH)_