### PR TITLE
Update typography token editing controls and letter spacing range

### DIFF
--- a/packages/docs/learn/theme/customizing-theme.mdx
+++ b/packages/docs/learn/theme/customizing-theme.mdx
@@ -78,6 +78,7 @@ Click any token to open color picker. Set a direct color value or reference anot
 
 Text tokens define typography styles with font family, size, weight, line height, and letter spacing.
 
+{/* TODO: Update image — font size and line height are now sliders, not numeric inputs */}
 <img src="/images/theme/theme-typography.png" alt="Typography section of the theme page showing editing a text token" />
 
 ```tsx
@@ -95,10 +96,10 @@ New tokens duplicate the properties from the first token. Typography tokens auto
 
 Click any text token to edit:
 
-- **Font size** — Pixel value
-- **Line height** — Pixel value
+- **Font size** — Slider in pixels
+- **Line height** — Slider in pixels
 - **Font weight** — Slider based on font's supported weights
-- **Letter spacing** — Slider from `-0.05em` to `0.05em`
+- **Letter spacing** — Slider from `-0.1em` to `0.1em`
 
 ### Changing font families
 


### PR DESCRIPTION
Corrects the theme typography editor docs: font size and line height are sliders, and the letter spacing slider range is `-0.1em` to `0.1em`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MinTWr8JefB5tiVJ3BewWN)_