### PR TITLE
Docs: canvas toolbar Insert panel, flow canvas editing, Layers section

### DIFF
--- a/packages/docs/learn/design-mode/adding-elements.mdx
+++ b/packages/docs/learn/design-mode/adding-elements.mdx
@@ -31,7 +31,9 @@ You can also use these keyboard shortcuts after selecting an element:
 - Quick insert left: <kbd>Ctrl</kbd> + <kbd>J</kbd>
 - Quick insert right: <kbd>Ctrl</kbd> + <kbd>L</kbd>
 
-## Method 2: Drag and drop from the Insert panel
+## Method 2: Insert panel
+
+{/* TODO: Update video — the Insert panel now opens from the toolbar at the bottom of the canvas, not the left panel */}
 
 <video
   autoPlay
@@ -42,15 +44,15 @@ You can also use these keyboard shortcuts after selecting an element:
   src="https://hevpkratkeuc60w7.public.blob.vercel-storage.com/drag-drop-insert-panel.mp4"
 />
 
-1. Click on the Insert tab in the left panel
+1. Click the **Insert** <Icon icon="plus" size={16} /> button in the toolbar at the bottom of the canvas
 2. Find the element you want to add
-3. Drag it directly onto your canvas
+3. Click it or drag it directly onto your canvas
 
 #### Tabs
 
 There are two tabs in the Insert panel:
 
-- **Your library** contains basic elements like text, images, and icons, as well as components like buttons, inputs from your design system.
+- **Components** contains basic elements like text, images, and icons, as well as components like buttons and inputs from your design system.
 - **Snippets** contains larger, pre-built compositions like page headers, navigation bars, card layouts, and other complex UI patterns.
 
 ## Method 3: Insert tools

--- a/packages/docs/learn/design-mode/adding-elements.mdx
+++ b/packages/docs/learn/design-mode/adding-elements.mdx
@@ -31,7 +31,7 @@ You can also use these keyboard shortcuts after selecting an element:
 - Quick insert left: <kbd>Ctrl</kbd> + <kbd>J</kbd>
 - Quick insert right: <kbd>Ctrl</kbd> + <kbd>L</kbd>
 
-## Method 2: Insert panel
+## Method 2: Drag and drop from the Insert panel
 
 {/* TODO: Update video — the Insert panel now opens from the toolbar at the bottom of the canvas, not the left panel */}
 
@@ -46,7 +46,7 @@ You can also use these keyboard shortcuts after selecting an element:
 
 1. Click the **Insert** <Icon icon="plus" size={16} /> button in the toolbar at the bottom of the canvas
 2. Find the element you want to add
-3. Click it or drag it directly onto your canvas
+3. Drag it directly onto your canvas
 
 #### Tabs
 

--- a/packages/docs/learn/design-mode/layers.mdx
+++ b/packages/docs/learn/design-mode/layers.mdx
@@ -9,7 +9,9 @@ The Layers panel shows your design's element hierarchy as a tree structure.
   <img src="/images/design-mode/layers.png" alt="Layers panel showing the element hierarchy" />
 </Frame>
 
-To open the layers panel, click the **Page** tab in the left sidebar.
+The **Layers** section is always visible in the left panel while you design.
+
+{/* TODO: Update image — the left panel no longer has a Page tab; Layers is an always-visible section */}
 
 <Frame>
   <img src="/images/design-mode/layers-toggle.png" alt="Layers panel showing the element hierarchy" />

--- a/packages/docs/learn/editor/overview.mdx
+++ b/packages/docs/learn/editor/overview.mdx
@@ -48,13 +48,13 @@ You have the following panels available to you:
 
 **Layers** — View and organize the element hierarchy for the current page. Select, reorder, or group elements. Shows the complete component tree.
 
-**Insert** — Browse and insert components and snippets. Search or drag elements onto the canvas. Switches between snippet and component libraries.
-
 ### Canvas (center)
 
 Your design surface where elements appear at their actual rendered size. The canvas shows exactly how your design will look at the current breakpoint.
 
 Unlike infinite canvas tools, Subframe uses flexbox for layout (not absolute positioning). Elements flow and arrange using Stacks, resize responsively, and adapt to different screen sizes automatically. If you're familiar with Figma, this works similarly to auto-layout.
+
+A toolbar at the bottom of the canvas gives you quick access to actions, the **Insert** <Icon icon="plus" size={16} /> panel for browsing components and snippets, comments, and annotations.
 
 ### Inspector (right panel)
 

--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -21,6 +21,16 @@ Double-click a flow name in the pages sidebar to rename it. Press <kbd>Enter</kb
 
 You can also drag pages directly into a flow from the pages list when editing a page.
 
+## Editing pages on the flow canvas
+
+You can edit pages directly on the flow canvas without opening them:
+
+- Click an element on any page to select it, then edit its properties in the Inspector panel
+- Drag an element from one page to another to move it between pages
+- Use the **Layers** section in the left panel to view and navigate each page's element hierarchy
+
+To open a page in its own editor, click **Edit page** in the page's header.
+
 ## Duplicating a flow
 
 1. Click <Icon icon="ellipsis" size={16} /> on a flow in the pages sidebar

--- a/packages/docs/learn/snippets/snippets.mdx
+++ b/packages/docs/learn/snippets/snippets.mdx
@@ -22,7 +22,7 @@ Unlike components, changes to snippets will not affect anywhere that uses them.
 
 There are two ways to insert snippets:
 
-- In the left panel, go to **Insert** > **Snippets**
+- Open the **Insert** <Icon icon="plus" size={16} /> panel from the toolbar at the bottom of the canvas and select **Snippets**
 - Search for the snippet using the [quick insert](/learn/design-mode/adding-elements) <Icon icon="plus" size={16} /> menu
 
 See [adding elements](/learn/design-mode/adding-elements) for more info.


### PR DESCRIPTION
Updates the docs for the editor's canvas editing changes:

- The Insert panel now opens from the toolbar at the bottom of the canvas instead of the left panel (Adding elements, Editor overview, Snippets)
- The left panel no longer has a Page tab; Layers is an always-visible section (Layers)
- Pages can be edited directly on the flow canvas: select and edit elements, drag elements between pages, and browse each page's hierarchy in the Layers section (Flows)