### PR TITLE
Update Insert panel docs: replace tabs with sections

### DIFF
--- a/packages/docs/learn/design-mode/adding-elements.mdx
+++ b/packages/docs/learn/design-mode/adding-elements.mdx
@@ -48,12 +48,13 @@ You can also use these keyboard shortcuts after selecting an element:
 2. Find the element you want to add
 3. Drag it directly onto your canvas
 
-#### Tabs
+#### What's in the panel
 
-There are two tabs in the Insert panel:
+Search across everything from the bar at the top, or browse the sections:
 
-- **Components** contains basic elements like text, images, and icons, as well as components like buttons and inputs from your design system.
-- **Snippets** contains larger, pre-built compositions like page headers, navigation bars, card layouts, and other complex UI patterns.
+- **Basic elements** — text, stacks, icons, images, and dividers.
+- **Components** — buttons, inputs, and other components from your design system.
+- **Snippets** — larger, pre-built compositions like page headers, navigation bars, and card layouts.
 
 ## Method 3: Insert tools
 


### PR DESCRIPTION
The Insert panel no longer uses Components/Snippets tabs. It's now a single searchable list with a basic-elements row, a Components section, and Snippets sections. This updates the "Adding elements" doc to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg4soku7BbP9ZX3B43FR2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg4soku7BbP9ZX3B43FR2s)_