### PR TITLE
Document deleting a flow

### DIFF
--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -38,6 +38,16 @@ To open a page in its own editor, click **Edit page** in the page's header.
 
 Duplicating a flow copies all of its pages along with the flow's [prototype](/learn/prototype-mode/overview).
 
+## Deleting a flow
+
+1. Click <Icon icon="ellipsis" size={16} /> on a flow in the pages sidebar
+2. Select **Delete flow...**
+3. Confirm in the dialog
+
+Deleting a flow also deletes every page inside it. To keep those pages, [move them to another flow](/learn/pages/pages) before deleting.
+
+<Warning>Deleting a flow can't be undone.</Warning>
+
 ## FAQ
 
 <AccordionGroup>

--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -46,7 +46,7 @@ Duplicating a flow copies all of its pages along with the flow's [prototype](/le
 
 Deleting a flow also deletes every page inside it. To keep those pages, move them to another flow with **Move to...** before deleting.
 
-<Warning>Deleting a flow can't be undone.</Warning>
+<Warning>Deleting a flow can only be undone using project-level version history</Warning>
 
 ## FAQ
 

--- a/packages/docs/learn/flows/flows.mdx
+++ b/packages/docs/learn/flows/flows.mdx
@@ -44,7 +44,7 @@ Duplicating a flow copies all of its pages along with the flow's [prototype](/le
 2. Select **Delete flow...**
 3. Confirm in the dialog
 
-Deleting a flow also deletes every page inside it. To keep those pages, [move them to another flow](/learn/pages/pages) before deleting.
+Deleting a flow also deletes every page inside it. To keep those pages, move them to another flow with **Move to...** before deleting.
 
 <Warning>Deleting a flow can't be undone.</Warning>
 


### PR DESCRIPTION
Adds a **Deleting a flow** section to the Flows doc. The flow actions menu includes a **Delete flow...** item that opens a confirmation dialog, and deleting a flow removes the pages inside it. This was the one flow action missing from the page (Create, Rename, Add pages, Edit, Duplicate were already covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCe5tMHUNEsKyrD5xptTf4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCe5tMHUNEsKyrD5xptTf4)_