### PR TITLE
Clarify recovery and version history guidance

### DIFF
--- a/packages/docs/learn/ask-ai/prompt-to-design.mdx
+++ b/packages/docs/learn/ask-ai/prompt-to-design.mdx
@@ -88,8 +88,8 @@ Ask AI is great for generating new designs or making broad changes to your page.
   changes applied through MCP or API tools.
 
   To revert a tool-applied change, restore the affected page, component, snippet, or theme using
-  [Version history](/learn/projects/version-history). Use project version history for deleted resources
-  or changes spanning multiple resources.
+  [Version history](/learn/projects/version-history). Use project version history to recover deleted items
+  or roll back changes across multiple parts of your project.
 </Accordion>
 
 </AccordionGroup>

--- a/packages/docs/learn/ask-ai/prompt-to-design.mdx
+++ b/packages/docs/learn/ask-ai/prompt-to-design.mdx
@@ -84,8 +84,12 @@ Ask AI is great for generating new designs or making broad changes to your page.
 </Accordion>
 
 <Accordion title="How do I undo changes?">
-  Press <kbd>Cmd</kbd> + <kbd>Z</kbd> to undo. Subframe maintains full undo history, so you can step back through
-  multiple changes. You can also use [Version history](/learn/projects/version-history) to restore a previous state.
+  <kbd>Cmd</kbd> + <kbd>Z</kbd> undoes changes made directly in the visual editor. It does not revert
+  changes applied through MCP or API tools.
+
+  To revert a tool-applied change, restore the affected page, component, snippet, or theme using
+  [Version history](/learn/projects/version-history). Use project version history for deleted resources
+  or changes spanning multiple resources.
 </Accordion>
 
 </AccordionGroup>

--- a/packages/docs/learn/projects/version-history.mdx
+++ b/packages/docs/learn/projects/version-history.mdx
@@ -22,7 +22,7 @@ Use project-level version history when you need to roll back multiple changes at
 2. Click the **•••** options menu beside its name
 3. Select **Version history...**
 4. Select a version from the timeline to preview it
-5. Click **Restore** to revert that resource to the selected version
+5. Click **Restore** to revert the page, component, or snippet to the selected version
 
 ## Theme version history
 
@@ -34,11 +34,11 @@ Use project-level version history when you need to roll back multiple changes at
 
 ## Restoring versions
 
-Resource version history restores only the selected page, component, snippet, or theme. Use it when you
-want to undo a change without affecting unrelated work.
+Version history for an individual page, component, snippet, or theme restores only that item. Use it to undo
+a change without affecting the rest of your project.
 
-Project version history restores the state of the entire project, including pages, components, snippets,
-and the theme. Use it for deleted resources or when you need to roll back changes spanning multiple resources.
+Project version history restores the entire project, including all pages, components, snippets, and the theme.
+Use it to recover deleted items or roll back changes across multiple parts of your project.
 
 ## Version retention
 

--- a/packages/docs/learn/projects/version-history.mdx
+++ b/packages/docs/learn/projects/version-history.mdx
@@ -16,21 +16,29 @@ Use project-level version history when you need to roll back multiple changes at
 3. Select the version timestamp from the dropdown in the banner at the top
 4. Click **Restore** to revert to that version.
 
-## Page, component, and theme version history
+## Page, component, and snippet version history
 
-1. Open a page, component, or theme in the editor
-2. Click the **clock icon** in the toolbar
-3. Select a version from the timeline to preview it
-4. Click **Restore** to revert to that version.
+1. Open the page, component, or snippet in the editor
+2. Click the **•••** options menu beside its name
+3. Select **Version history...**
+4. Select a version from the timeline to preview it
+5. Click **Restore** to revert that resource to the selected version
+
+## Theme version history
+
+1. Open **Theme** under **Design System**
+2. Click **•••** in the theme toolbar
+3. Select **Version history**
+4. Select a version from the timeline to preview it
+5. Click **Restore** to revert the theme to the selected version
 
 ## Restoring versions
 
-When you restore a version, all changes are restored across your project, including:
+Resource version history restores only the selected page, component, snippet, or theme. Use it when you
+want to undo a change without affecting unrelated work.
 
-- Page designs
-- Component edits
-- Theme changes
-- All other project modifications
+Project version history restores the state of the entire project, including pages, components, snippets,
+and the theme. Use it for deleted resources or when you need to roll back changes spanning multiple resources.
 
 ## Version retention
 


### PR DESCRIPTION
Clarifies that Cmd+Z only undoes visual-editor changes and directs tool-applied recovery to version history. Documents separate resource-level flows for pages, components, snippets, and themes. Explains when resource history or whole-project history should be used.